### PR TITLE
Determinism fixes

### DIFF
--- a/src/stella_vslam/CMakeLists.txt
+++ b/src/stella_vslam/CMakeLists.txt
@@ -129,6 +129,15 @@ if(USE_ARUCO)
     target_compile_definitions(${PROJECT_NAME} PUBLIC USE_ARUCO)
 endif()
 
+# Determinism
+set (DETERMINISTIC OFF CACHE BOOL "Use deterministic code")
+if (DETERMINISTIC)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC DETERMINISTIC)
+    message(STATUS "Determinism: ENABLED")
+else()
+    message(STATUS "Determinism: DISABLED")
+endif()
+
 # ----- Configure stella_vslam library -----
 
 # Include directories

--- a/src/stella_vslam/data/graph_node.cc
+++ b/src/stella_vslam/data/graph_node.cc
@@ -2,6 +2,16 @@
 #include "stella_vslam/data/graph_node.h"
 #include "stella_vslam/data/landmark.h"
 
+#ifdef DETERMINISTIC
+namespace {
+    struct {
+        bool operator()(const std::pair<unsigned int, std::shared_ptr<stella_vslam::data::keyframe>>& a, const std::pair<unsigned int, std::shared_ptr<stella_vslam::data::keyframe>>& b) {
+            return a.first < b.first || ( a.first == b.first && a.second != nullptr && (b.second == nullptr || a.second->id_ < b.second->id_) );
+        }
+    } cmp_weight_keyfrm_pairs;
+}
+#endif
+
 namespace stella_vslam {
 namespace data {
 
@@ -57,7 +67,12 @@ void graph_node::erase_all_connections() {
 void graph_node::update_connections() {
     const auto landmarks = owner_keyfrm_.lock()->get_landmarks();
 
+#ifdef DETERMINISTIC
+    std::map<std::weak_ptr<keyframe>, unsigned int, id_less_than_weak<keyframe>> keyfrm_weights;
+#else
     std::map<std::weak_ptr<keyframe>, unsigned int, std::owner_less<std::weak_ptr<keyframe>>> keyfrm_weights;
+#endif
+
     for (const auto& lm : landmarks) {
         if (!lm) {
             continue;
@@ -93,6 +108,8 @@ void graph_node::update_connections() {
         auto keyfrm = keyfrm_weight.first.lock();
         const auto weight = keyfrm_weight.second;
 
+        // NB in DETERMINISTIC mode, will select the nearest_covisibility with greatest id_ if
+        // weights are the same due to ordering of keyfrm_weights
         if (max_weight <= weight) {
             max_weight = weight;
             nearest_covisibility = keyfrm;
@@ -114,8 +131,14 @@ void graph_node::update_connections() {
         covisibility->graph_node_->add_connection(owner_keyfrm_.lock(), weight);
     }
 
+#ifdef DETERMINISTIC
+    // sort with weights and keyframe IDs for consistency; IDs are also in reverse order
+    // to match selection of nearest_covisibility.
+    std::sort(weight_covisibility_pairs.rbegin(), weight_covisibility_pairs.rend(), cmp_weight_keyfrm_pairs);
+#else
     // sort with weights
     std::sort(weight_covisibility_pairs.rbegin(), weight_covisibility_pairs.rend());
+#endif
 
     decltype(ordered_covisibilities_) ordered_covisibilities;
     ordered_covisibilities.reserve(weight_covisibility_pairs.size());
@@ -129,7 +152,12 @@ void graph_node::update_connections() {
     {
         std::lock_guard<std::mutex> lock(mtx_);
 
+#ifdef DETERMINISTIC
+        connected_keyfrms_and_weights_ = std::map<std::weak_ptr<keyframe>, unsigned int, id_less_than_weak<keyframe>>(keyfrm_weights.begin(), keyfrm_weights.end());
+#else
         connected_keyfrms_and_weights_ = std::map<std::weak_ptr<keyframe>, unsigned int, std::owner_less<std::weak_ptr<keyframe>>>(keyfrm_weights.begin(), keyfrm_weights.end());
+#endif
+
         ordered_covisibilities_ = ordered_covisibilities;
         ordered_weights_ = ordered_weights;
 
@@ -156,8 +184,13 @@ void graph_node::update_covisibility_orders_impl() {
         weight_keyfrm_pairs.emplace_back(std::make_pair(keyfrm_and_weight.second, keyfrm_and_weight.first.lock()));
     }
 
+#ifdef DETERMINISTIC
+    // sort with weights and keyframe IDs for consistency
+    std::sort(weight_keyfrm_pairs.rbegin(), weight_keyfrm_pairs.rend(), cmp_weight_keyfrm_pairs);
+#else
     // sort with weights
     std::sort(weight_keyfrm_pairs.rbegin(), weight_keyfrm_pairs.rend());
+#endif
 
     ordered_covisibilities_.clear();
     ordered_covisibilities_.reserve(weight_keyfrm_pairs.size());

--- a/src/stella_vslam/data/graph_node.h
+++ b/src/stella_vslam/data/graph_node.h
@@ -157,7 +157,11 @@ private:
     std::weak_ptr<keyframe> const owner_keyfrm_;
 
     //! all connected keyframes and their weights
+#ifdef DETERMINISTIC
+    std::map<std::weak_ptr<keyframe>, unsigned int, id_less_than_weak<keyframe>> connected_keyfrms_and_weights_;
+#else
     std::map<std::weak_ptr<keyframe>, unsigned int, std::owner_less<std::weak_ptr<keyframe>>> connected_keyfrms_and_weights_;
+#endif
 
     //! minimum threshold for covisibility graph connection
     static constexpr unsigned int weight_thr_ = 15;
@@ -169,12 +173,20 @@ private:
     //! parent of spanning tree
     std::weak_ptr<keyframe> spanning_parent_;
     //! children of spanning tree
+#ifdef DETERMINISTIC
+    std::set<std::weak_ptr<keyframe>, id_less_than_weak<keyframe>> spanning_children_;
+#else
     std::set<std::weak_ptr<keyframe>, std::owner_less<std::weak_ptr<keyframe>>> spanning_children_;
+#endif
     //! flag which indicates spanning tree is not set yet or not
     bool spanning_parent_is_not_set_;
 
     //! loop edges
+#ifdef DETERMINISTIC
+    std::set<std::weak_ptr<keyframe>, id_less_than_weak<keyframe>> loop_edges_;
+#else
     std::set<std::weak_ptr<keyframe>, std::owner_less<std::weak_ptr<keyframe>>> loop_edges_;
+#endif
 
     //! need mutex for access to connections
     mutable std::mutex mtx_;

--- a/src/stella_vslam/data/landmark.h
+++ b/src/stella_vslam/data/landmark.h
@@ -24,7 +24,12 @@ class landmark {
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
+#ifdef DETERMINISTIC
+    //! Data structure for sorting keyframes by ID for consistent results in local map cleaning/BA
+    using observations_t = std::map<std::weak_ptr<keyframe>, unsigned int, id_less_than_weak<keyframe>>;
+#else
     using observations_t = std::map<std::weak_ptr<keyframe>, unsigned int, std::owner_less<std::weak_ptr<keyframe>>>;
+#endif
 
     //! constructor
     landmark(const Vec3_t& pos_w, const std::shared_ptr<keyframe>& ref_keyfrm);

--- a/src/stella_vslam/mapping_module.h
+++ b/src/stella_vslam/mapping_module.h
@@ -53,6 +53,9 @@ public:
     //! Queue a keyframe to process the mapping
     void queue_keyframe(const std::shared_ptr<data::keyframe>& keyfrm);
 
+    //! Check if keyframe is queued
+    bool keyframe_is_queued() const;
+
     //! Get the number of queued keyframes
     unsigned int get_num_queued_keyframes() const;
 
@@ -104,6 +107,17 @@ public:
     //! Abort the local BA externally
     //! (NOTE: this function does not wait for abort)
     void abort_local_BA();
+
+#ifdef DETERMINISTIC
+    //-----------------------------------------
+    // management for synchronization with tracking
+
+    //! Signal that processing is done
+    std::condition_variable processing_cv_;
+
+    //! Mutex for blocking tracking until we're done
+    std::mutex mtx_processing_;
+#endif
 
 private:
     //-----------------------------------------
@@ -223,9 +237,6 @@ private:
 
     //! mutex for access to keyframe queue
     mutable std::mutex mtx_keyfrm_queue_;
-
-    //! Check if keyframe is queued
-    bool keyframe_is_queued() const;
 
     //! queue for keyframes
     std::list<std::shared_ptr<data::keyframe>> keyfrms_queue_;

--- a/src/stella_vslam/mapping_module.h
+++ b/src/stella_vslam/mapping_module.h
@@ -140,11 +140,21 @@ private:
     void update_new_keyframe();
 
     //! Get the first and second order covisibilities of current keyframe
+#ifdef DETERMINISTIC
+    id_ordered_set<data::keyframe> get_second_order_covisibilities(const unsigned int first_order_thr,
+                                                                    const unsigned int second_order_thr);
+#else
     std::unordered_set<std::shared_ptr<data::keyframe>> get_second_order_covisibilities(const unsigned int first_order_thr,
                                                                                         const unsigned int second_order_thr);
 
+#endif
+
     //! Fuse duplicated landmarks between current keyframe and covisibility keyframes
+#ifdef DETERMINISTIC
+    void fuse_landmark_duplication(const id_ordered_set<data::keyframe>& fuse_tgt_keyfrms);
+#else
     void fuse_landmark_duplication(const std::unordered_set<std::shared_ptr<data::keyframe>>& fuse_tgt_keyfrms);
+#endif
 
     //! Check if pause is requested and not prevented
     bool pause_is_requested_and_not_prevented() const;

--- a/src/stella_vslam/match/fuse.cc
+++ b/src/stella_vslam/match/fuse.cc
@@ -4,7 +4,9 @@
 #include "stella_vslam/data/landmark.h"
 
 #include <vector>
+#ifndef DETERMINISTIC
 #include <unordered_set>
+#endif
 
 namespace stella_vslam {
 namespace match {
@@ -271,7 +273,11 @@ unsigned int fuse::replace_duplication(data::map_database* map_db,
 }
 
 template unsigned int fuse::replace_duplication(data::map_database*, const std::shared_ptr<data::keyframe>&, const std::vector<std::shared_ptr<data::landmark>>&, const float);
+#ifdef DETERMINISTIC
+template unsigned int fuse::replace_duplication(data::map_database*, const std::shared_ptr<data::keyframe>&, const id_ordered_set<data::landmark>&, const float);
+#else
 template unsigned int fuse::replace_duplication(data::map_database*, const std::shared_ptr<data::keyframe>&, const std::unordered_set<std::shared_ptr<data::landmark>>&, const float);
+#endif
 
 } // namespace match
 } // namespace stella_vslam

--- a/src/stella_vslam/match/robust.cc
+++ b/src/stella_vslam/match/robust.cc
@@ -179,7 +179,7 @@ unsigned int robust::match_for_triangulation(const std::shared_ptr<data::keyfram
 
 unsigned int robust::match_keyframes(const std::shared_ptr<data::keyframe>& keyfrm1, const std::shared_ptr<data::keyframe>& keyfrm2,
                                      std::vector<std::shared_ptr<data::landmark>>& matched_lms_in_frm,
-                                     bool validate_with_essential_solver) const {
+                                     bool validate_with_essential_solver, bool use_fixed_seed ) const {
     // Initialization
     const auto num_frm_keypts = keyfrm1->frm_obs_.num_keypts_;
     const auto keyfrm_lms = keyfrm2->get_landmarks();
@@ -192,7 +192,7 @@ unsigned int robust::match_keyframes(const std::shared_ptr<data::keyframe>& keyf
 
     // Extract only inliers with eight-point RANSAC
     if (validate_with_essential_solver) {
-        solve::essential_solver solver(keyfrm1->frm_obs_.bearings_, keyfrm2->frm_obs_.bearings_, matches);
+        solve::essential_solver solver(keyfrm1->frm_obs_.bearings_, keyfrm2->frm_obs_.bearings_, matches, use_fixed_seed);
         solver.find_via_ransac(50, false);
         if (!solver.solution_is_valid()) {
             return 0;
@@ -226,7 +226,8 @@ unsigned int robust::match_keyframes(const std::shared_ptr<data::keyframe>& keyf
 }
 
 unsigned int robust::match_frame_and_keyframe(data::frame& frm, const std::shared_ptr<data::keyframe>& keyfrm,
-                                              std::vector<std::shared_ptr<data::landmark>>& matched_lms_in_frm) const {
+                                              std::vector<std::shared_ptr<data::landmark>>& matched_lms_in_frm,
+                                              bool use_fixed_seed) const {
     // Initialization
     const auto num_frm_keypts = frm.frm_obs_.num_keypts_;
     const auto keyfrm_lms = keyfrm->get_landmarks();
@@ -238,7 +239,7 @@ unsigned int robust::match_frame_and_keyframe(data::frame& frm, const std::share
     brute_force_match(frm.frm_obs_, keyfrm, matches);
 
     // Extract only inliers with eight-point RANSAC
-    solve::essential_solver solver(frm.frm_obs_.bearings_, keyfrm->frm_obs_.bearings_, matches);
+    solve::essential_solver solver(frm.frm_obs_.bearings_, keyfrm->frm_obs_.bearings_, matches, use_fixed_seed);
     solver.find_via_ransac(50, false);
     if (!solver.solution_is_valid()) {
         return 0;

--- a/src/stella_vslam/match/robust.h
+++ b/src/stella_vslam/match/robust.h
@@ -29,10 +29,11 @@ public:
 
     unsigned int match_keyframes(const std::shared_ptr<data::keyframe>& keyfrm1, const std::shared_ptr<data::keyframe>& keyfrm2,
                                  std::vector<std::shared_ptr<data::landmark>>& matched_lms_in_frm,
-                                 bool validate_with_essential_solver = true) const;
+                                 bool validate_with_essential_solver = true, bool use_fixed_seed = false) const;
 
     unsigned int match_frame_and_keyframe(data::frame& frm, const std::shared_ptr<data::keyframe>& keyfrm,
-                                          std::vector<std::shared_ptr<data::landmark>>& matched_lms_in_frm) const;
+                                          std::vector<std::shared_ptr<data::landmark>>& matched_lms_in_frm,
+                                          bool use_fixed_seed = false) const;
 
     unsigned int brute_force_match(const data::frame_observation& frm_obs, const std::shared_ptr<data::keyframe>& keyfrm, std::vector<std::pair<int, int>>& matches) const;
 

--- a/src/stella_vslam/module/frame_tracker.cc
+++ b/src/stella_vslam/module/frame_tracker.cc
@@ -12,8 +12,8 @@
 namespace stella_vslam {
 namespace module {
 
-frame_tracker::frame_tracker(camera::base* camera, const unsigned int num_matches_thr)
-    : camera_(camera), num_matches_thr_(num_matches_thr), pose_optimizer_() {}
+frame_tracker::frame_tracker(camera::base* camera, const unsigned int num_matches_thr, bool use_fixed_seed)
+    : camera_(camera), num_matches_thr_(num_matches_thr), use_fixed_seed_(use_fixed_seed), pose_optimizer_() {}
 
 bool frame_tracker::motion_based_track(data::frame& curr_frm, const data::frame& last_frm, const Mat44_t& velocity) const {
     match::projection projection_matcher(0.9, true);
@@ -99,7 +99,7 @@ bool frame_tracker::robust_match_based_track(data::frame& curr_frm, const data::
     // Search 2D-2D matches between the ref keyframes and the current frame
     // to acquire 2D-3D matches between the frame keypoints and 3D points observed in the ref keyframe
     std::vector<std::shared_ptr<data::landmark>> matched_lms_in_curr;
-    auto num_matches = robust_matcher.match_frame_and_keyframe(curr_frm, ref_keyfrm, matched_lms_in_curr);
+    auto num_matches = robust_matcher.match_frame_and_keyframe(curr_frm, ref_keyfrm, matched_lms_in_curr, use_fixed_seed_);
 
     if (num_matches < num_matches_thr_) {
         spdlog::debug("robust match based tracking failed: {} matches < {}", num_matches, num_matches_thr_);

--- a/src/stella_vslam/module/frame_tracker.h
+++ b/src/stella_vslam/module/frame_tracker.h
@@ -22,7 +22,7 @@ namespace module {
 
 class frame_tracker {
 public:
-    explicit frame_tracker(camera::base* camera, const unsigned int num_matches_thr = 20);
+    explicit frame_tracker(camera::base* camera, const unsigned int num_matches_thr = 20, bool use_fixed_seed = false);
 
     bool motion_based_track(data::frame& curr_frm, const data::frame& last_frm, const Mat44_t& velocity) const;
 
@@ -35,6 +35,8 @@ private:
 
     const camera::base* camera_;
     const unsigned int num_matches_thr_;
+    //! Use fixed random seed for RANSAC if true
+    const bool use_fixed_seed_;
 
     const optimize::pose_optimizer pose_optimizer_;
 };

--- a/src/stella_vslam/module/initializer.cc
+++ b/src/stella_vslam/module/initializer.cc
@@ -51,6 +51,10 @@ double initializer::get_initial_frame_timestamp() const {
     return init_frm_stamp_;
 }
 
+bool initializer::get_use_fixed_seed() const {
+    return use_fixed_seed_;
+}
+
 bool initializer::initialize(const camera::setup_type_t setup_type,
                              data::bow_vocabulary* bow_vocab, data::frame& curr_frm) {
     switch (setup_type) {

--- a/src/stella_vslam/module/initializer.h
+++ b/src/stella_vslam/module/initializer.h
@@ -50,6 +50,9 @@ public:
     //! Get the initial frame stamp which succeeded in initialization
     double get_initial_frame_timestamp() const;
 
+    //! Get whether to use a fixed seed for RANSAC
+    bool get_use_fixed_seed() const;
+
     //! Initialize with the current frame
     bool initialize(const camera::setup_type_t setup_type,
                     data::bow_vocabulary* bow_vocab, data::frame& curr_frm);

--- a/src/stella_vslam/module/local_map_updater.h
+++ b/src/stella_vslam/module/local_map_updater.h
@@ -15,7 +15,12 @@ namespace module {
 
 class local_map_updater {
 public:
+#ifdef DETERMINISTIC
+    //! Data structure for sorting keyframes by ID for consistent results in find_local_keyframes()
+    using keyframe_weights_t = std::map<std::shared_ptr<data::keyframe>, unsigned int, id_less_than_shared<data::keyframe>>;
+#else
     using keyframe_weights_t = std::unordered_map<std::shared_ptr<data::keyframe>, unsigned int>;
+#endif
 
     //! Constructor
     explicit local_map_updater(const data::frame& curr_frm, const unsigned int max_num_local_keyfrms);

--- a/src/stella_vslam/module/loop_detector.cc
+++ b/src/stella_vslam/module/loop_detector.cc
@@ -25,7 +25,8 @@ loop_detector::loop_detector(data::bow_database* bow_db, data::bow_vocabulary* b
       num_matches_thr_(yaml_node["num_matches_thr"].as<unsigned int>(20)),
       num_matches_thr_brute_force_(yaml_node["num_matches_thr_robust_matcher"].as<unsigned int>(0)),
       num_optimized_inliers_thr_(yaml_node["num_optimized_inliers_thr"].as<unsigned int>(20)),
-      top_n_covisibilities_to_search_(yaml_node["top_n_covisibilities_to_search"].as<unsigned int>(0)) {
+      top_n_covisibilities_to_search_(yaml_node["top_n_covisibilities_to_search"].as<unsigned int>(0)),
+      use_fixed_seed_(yaml_node["use_fixed_seed"].as<bool>(false)) {
     spdlog::debug("CONSTRUCT: loop_detector");
 }
 
@@ -404,7 +405,8 @@ bool loop_detector::select_loop_candidate_via_Sim3(const std::unordered_set<std:
         }
         // Setup PnP solver
         auto pnp_solver = std::unique_ptr<solve::pnp_solver>(new solve::pnp_solver(valid_bearings, valid_keypts, valid_landmarks,
-                                                                                   cur_keyfrm_->orb_params_->scale_factors_));
+                                                                                   cur_keyfrm_->orb_params_->scale_factors_,
+                                                                                   use_fixed_seed_));
 
         pnp_solver->find_via_ransac(30);
         if (!pnp_solver->solution_is_valid()) {

--- a/src/stella_vslam/module/loop_detector.h
+++ b/src/stella_vslam/module/loop_detector.h
@@ -181,6 +181,9 @@ private:
 
     //! the keyframe ID when the previouls loop correction was performed
     unsigned int prev_loop_correct_keyfrm_id_ = 0;
+
+    //! Use fixed random seed for RANSAC if true
+    const bool use_fixed_seed_;
 };
 
 } // namespace module

--- a/src/stella_vslam/module/relocalizer.cc
+++ b/src/stella_vslam/module/relocalizer.cc
@@ -12,11 +12,12 @@ namespace module {
 
 relocalizer::relocalizer(const double bow_match_lowe_ratio, const double proj_match_lowe_ratio,
                          const double robust_match_lowe_ratio,
-                         const unsigned int min_num_bow_matches, const unsigned int min_num_valid_obs)
+                         const unsigned int min_num_bow_matches, const unsigned int min_num_valid_obs,
+                         const bool use_fixed_seed)
     : min_num_bow_matches_(min_num_bow_matches), min_num_valid_obs_(min_num_valid_obs),
       bow_matcher_(bow_match_lowe_ratio, true), proj_matcher_(proj_match_lowe_ratio, true),
       robust_matcher_(robust_match_lowe_ratio, false),
-      pose_optimizer_() {
+      pose_optimizer_(), use_fixed_seed_(use_fixed_seed) {
     spdlog::debug("CONSTRUCT: module::relocalizer");
 }
 
@@ -25,7 +26,8 @@ relocalizer::relocalizer(const YAML::Node& yaml_node)
                   yaml_node["proj_match_lowe_ratio"].as<double>(0.9),
                   yaml_node["robust_match_lowe_ratio"].as<double>(0.8),
                   yaml_node["min_num_bow_matches"].as<unsigned int>(20),
-                  yaml_node["min_num_valid_obs"].as<unsigned int>(50)) {
+                  yaml_node["min_num_valid_obs"].as<unsigned int>(50),
+                  yaml_node["use_fixed_seed"].as<bool>(false)) {
 }
 
 relocalizer::~relocalizer() {
@@ -254,7 +256,7 @@ std::unique_ptr<solve::pnp_solver> relocalizer::setup_pnp_solver(const std::vect
         valid_landmarks.at(i) = valid_assoc_lms.at(i)->get_pos_in_world();
     }
     // Setup PnP solver
-    return std::unique_ptr<solve::pnp_solver>(new solve::pnp_solver(valid_bearings, valid_keypts, valid_landmarks, scale_factors));
+    return std::unique_ptr<solve::pnp_solver>(new solve::pnp_solver(valid_bearings, valid_keypts, valid_landmarks, scale_factors, use_fixed_seed_));
 }
 
 } // namespace module

--- a/src/stella_vslam/module/relocalizer.h
+++ b/src/stella_vslam/module/relocalizer.h
@@ -23,7 +23,8 @@ public:
     //! Constructor
     explicit relocalizer(const double bow_match_lowe_ratio = 0.75, const double proj_match_lowe_ratio = 0.9,
                          const double robust_match_lowe_ratio = 0.8,
-                         const unsigned int min_num_bow_matches = 20, const unsigned int min_num_valid_obs = 50);
+                         const unsigned int min_num_bow_matches = 20, const unsigned int min_num_valid_obs = 50,
+                         const bool use_fixed_seed = false);
 
     explicit relocalizer(const YAML::Node& yaml_node);
 
@@ -67,6 +68,8 @@ private:
     const unsigned int min_num_bow_matches_;
     //! minimum threshold of the number of valid (= inlier after pose optimization) matches
     const unsigned int min_num_valid_obs_;
+    //! Use fixed random seed for RANSAC if true
+    const bool use_fixed_seed_;
 
     //! BoW matcher
     const match::bow_tree bow_matcher_;

--- a/src/stella_vslam/tracking_module.cc
+++ b/src/stella_vslam/tracking_module.cc
@@ -50,7 +50,7 @@ tracking_module::tracking_module(const std::shared_ptr<config>& cfg, data::map_d
       use_robust_matcher_for_relocalization_request_(get_use_robust_matcher_for_relocalization_request(util::yaml_optional_ref(cfg->yaml_node_, "Tracking"))),
       map_db_(map_db), bow_vocab_(bow_vocab), bow_db_(bow_db),
       initializer_(map_db, bow_db, util::yaml_optional_ref(cfg->yaml_node_, "Initializer")),
-      frame_tracker_(camera_, 10),
+      frame_tracker_(camera_, 10, initializer_.get_use_fixed_seed()),
       relocalizer_(util::yaml_optional_ref(cfg->yaml_node_, "Relocalizer")),
       pose_optimizer_(),
       keyfrm_inserter_(util::yaml_optional_ref(cfg->yaml_node_, "KeyframeInserter")) {

--- a/src/stella_vslam/tracking_module.cc
+++ b/src/stella_vslam/tracking_module.cc
@@ -162,6 +162,15 @@ std::shared_ptr<Mat44_t> tracking_module::feed_frame(data::frame curr_frm) {
         succeeded = track(relocalization_is_needed);
     }
 
+#ifdef DETERMINISTIC
+    // make sure the mapper has processed any new keyframes before doing anything else
+    std::unique_lock<std::mutex> mapping_lock(mapper_->mtx_processing_);
+    mapper_->processing_cv_.wait(
+        mapping_lock, [this]{ return mapper_->is_idle() && !mapper_->keyframe_is_queued(); }
+    );
+    mapping_lock.unlock();
+#endif
+
     // state transition
     if (succeeded) {
         tracking_state_ = tracker_state_t::Tracking;

--- a/src/stella_vslam/type.h
+++ b/src/stella_vslam/type.h
@@ -114,6 +114,27 @@ inline Vec2_t operator-(const cv::Point_<T>& v1, const Vec2_t& v2) {
     return v1 + (-v2);
 }
 
+#ifdef DETERMINISTIC
+// Comparators to allow ordering of classes with id_ member (keyframes, landmarks) to be ordered by ID.
+// Assume that null pointers have an ID of infinity, i.e. nullptr > any valid pointer.
+template <class T>
+struct id_less_than_shared {
+    bool operator()(const std::shared_ptr<T> a, const std::shared_ptr<T> b) const {
+        return a != nullptr && (b == nullptr || a->id_ < b->id_);
+    }
+};
+
+template <class T>
+struct id_less_than_weak {
+    bool operator()(const std::weak_ptr<T> a, const std::weak_ptr<T> b) const {
+        return !a.expired() && (b.expired() || a.lock()->id_ < b.lock()->id_);
+    }
+};
+
+template <class T>
+using id_ordered_set = std::set<std::shared_ptr<T>, id_less_than_shared<T>>;
+#endif  // DETERMINISTIC
+
 } // namespace stella_vslam
 
 #endif // STELLA_VSLAM_TYPE_H


### PR DESCRIPTION
Fixes #293:

1. Pass the `use_fixed_seed` parameter from the Initializer to other relevant classes where possible, and introduce equivalent parameters in other YAML nodes (Relocalizer, LoopDetector).
2. Force the tracker to wait until the mapper has finished every time it passes a new keyframe across (this is a brute force solution that could probably be improved).
3. Sort landmarks/keyframes by ID rather than memory address where relevant.

Since (2) and (3) will potentially impact performance, the relevant code changes are disabled by default, enabled by running `cmake` with `-DDETERMINISTIC=ON`. The parameters in (1) are optional in any case, and default to false to preserve existing behaviour.