### PR TITLE
Modify distribute_keypoints_via_tree (Remove max_num_keypoints parameter)

### DIFF
--- a/example/aist/equirectangular.yaml
+++ b/example/aist/equirectangular.yaml
@@ -20,7 +20,7 @@ Camera:
 #=====================#
 
 Preprocessing:
-  max_num_keypoints: 2000
+  min_size: 800
   mask_rectangles:
     - [0.0, 1.0, 0.0, 0.1]
     - [0.0, 1.0, 0.84, 1.0]

--- a/example/aist/fisyeye.yaml
+++ b/example/aist/fisyeye.yaml
@@ -30,7 +30,7 @@ Camera:
 #=====================#
 
 Preprocessing:
-  max_num_keypoints: 2000
+  min_size: 800
 
 #================#
 # orb parameters #

--- a/example/euroc/EuRoC_mono.yaml
+++ b/example/euroc/EuRoC_mono.yaml
@@ -31,8 +31,7 @@ Camera:
 #=====================#
 
 Preprocessing:
-  max_num_keypoints: 1000
-  ini_max_num_keypoints: 2000
+  min_size: 800
 
 #================#
 # ORB Parameters #

--- a/example/euroc/EuRoC_stereo.yaml
+++ b/example/euroc/EuRoC_stereo.yaml
@@ -57,8 +57,7 @@ StereoRectifier:
 #=====================#
 
 Preprocessing:
-  max_num_keypoints: 1000
-  ini_max_num_keypoints: 2000
+  min_size: 800
 
 #================#
 # ORB Parameters #

--- a/example/kitti/KITTI_mono_00-02.yaml
+++ b/example/kitti/KITTI_mono_00-02.yaml
@@ -31,8 +31,7 @@ Camera:
 #=====================#
 
 Preprocessing:
-  max_num_keypoints: 2000
-  ini_max_num_keypoints: 4000
+  min_size: 800
 
 #================#
 # ORB Parameters #

--- a/example/kitti/KITTI_mono_03.yaml
+++ b/example/kitti/KITTI_mono_03.yaml
@@ -31,8 +31,7 @@ Camera:
 #=====================#
 
 Preprocessing:
-  max_num_keypoints: 2000
-  ini_max_num_keypoints: 4000
+  min_size: 800
 
 #================#
 # ORB Parameters #

--- a/example/kitti/KITTI_mono_04-12.yaml
+++ b/example/kitti/KITTI_mono_04-12.yaml
@@ -31,8 +31,7 @@ Camera:
 #=====================#
 
 Preprocessing:
-  max_num_keypoints: 2000
-  ini_max_num_keypoints: 4000
+  min_size: 800
 
 #================#
 # ORB Parameters #

--- a/example/kitti/KITTI_stereo_00-02.yaml
+++ b/example/kitti/KITTI_stereo_00-02.yaml
@@ -33,8 +33,7 @@ Camera:
 #=====================#
 
 Preprocessing:
-  max_num_keypoints: 2000
-  ini_max_num_keypoints: 4000
+  min_size: 800
 
 #================#
 # ORB Parameters #

--- a/example/kitti/KITTI_stereo_03.yaml
+++ b/example/kitti/KITTI_stereo_03.yaml
@@ -33,8 +33,7 @@ Camera:
 #=====================#
 
 Preprocessing:
-  max_num_keypoints: 2000
-  ini_max_num_keypoints: 4000
+  min_size: 800
 
 #================#
 # ORB Parameters #

--- a/example/kitti/KITTI_stereo_04-12.yaml
+++ b/example/kitti/KITTI_stereo_04-12.yaml
@@ -33,8 +33,7 @@ Camera:
 #=====================#
 
 Preprocessing:
-  max_num_keypoints: 2000
-  ini_max_num_keypoints: 4000
+  min_size: 800
 
 #================#
 # ORB Parameters #

--- a/example/tum_rgbd/TUM_RGBD_mono_1.yaml
+++ b/example/tum_rgbd/TUM_RGBD_mono_1.yaml
@@ -31,8 +31,7 @@ Camera:
 #=====================#
 
 Preprocessing:
-  max_num_keypoints: 1000
-  ini_max_num_keypoints: 2000
+  min_size: 800
 
 #================#
 # ORB Parameters #

--- a/example/tum_rgbd/TUM_RGBD_mono_2.yaml
+++ b/example/tum_rgbd/TUM_RGBD_mono_2.yaml
@@ -31,8 +31,7 @@ Camera:
 #=====================#
 
 Preprocessing:
-  max_num_keypoints: 1000
-  ini_max_num_keypoints: 2000
+  min_size: 800
 
 #================#
 # ORB Parameters #

--- a/example/tum_rgbd/TUM_RGBD_mono_3.yaml
+++ b/example/tum_rgbd/TUM_RGBD_mono_3.yaml
@@ -31,8 +31,7 @@ Camera:
 #=====================#
 
 Preprocessing:
-  max_num_keypoints: 1000
-  ini_max_num_keypoints: 2000
+  min_size: 800
 
 #================#
 # ORB Parameters #

--- a/example/tum_rgbd/TUM_RGBD_rgbd_1.yaml
+++ b/example/tum_rgbd/TUM_RGBD_rgbd_1.yaml
@@ -33,8 +33,7 @@ Camera:
 #=====================#
 
 Preprocessing:
-  max_num_keypoints: 1000
-  ini_max_num_keypoints: 2000
+  min_size: 800
   depthmap_factor: 5000.0 # Note: Set it to 1.0 for the rosbag format data set.
 
 #================#

--- a/example/tum_rgbd/TUM_RGBD_rgbd_2.yaml
+++ b/example/tum_rgbd/TUM_RGBD_rgbd_2.yaml
@@ -33,8 +33,7 @@ Camera:
 #=====================#
 
 Preprocessing:
-  max_num_keypoints: 1000
-  ini_max_num_keypoints: 2000
+  min_size: 800
   depthmap_factor: 5000.0 # Note: Set it to 1.0 for the rosbag format data set.
 
 #================#

--- a/example/tum_rgbd/TUM_RGBD_rgbd_3.yaml
+++ b/example/tum_rgbd/TUM_RGBD_rgbd_3.yaml
@@ -33,8 +33,7 @@ Camera:
 #=====================#
 
 Preprocessing:
-  max_num_keypoints: 1000
-  ini_max_num_keypoints: 2000
+  min_size: 800
   depthmap_factor: 5000.0 # Note: Set it to 1.0 for the rosbag format data set.
 
 #================#

--- a/example/tum_vi/TUM_VI_mono.yaml
+++ b/example/tum_vi/TUM_VI_mono.yaml
@@ -32,8 +32,7 @@ Camera:
 #=====================#
 
 Preprocessing:
-  max_num_keypoints: 1000
-  ini_max_num_keypoints: 2000
+  min_size: 800
 
 #================#
 # ORB Parameters #

--- a/example/tum_vi/TUM_VI_stereo.yaml
+++ b/example/tum_vi/TUM_VI_stereo.yaml
@@ -59,8 +59,7 @@ StereoRectifier:
 #=====================#
 
 Preprocessing:
-  max_num_keypoints: 1000
-  ini_max_num_keypoints: 2000
+  min_size: 800
 
 #================#
 # ORB Parameters #

--- a/src/stella_vslam/feature/CMakeLists.txt
+++ b/src/stella_vslam/feature/CMakeLists.txt
@@ -4,9 +4,11 @@ target_sources(${PROJECT_NAME}
                ${CMAKE_CURRENT_SOURCE_DIR}/orb_params.h
                ${CMAKE_CURRENT_SOURCE_DIR}/orb_extractor.h
                ${CMAKE_CURRENT_SOURCE_DIR}/orb_extractor_node.h
+               ${CMAKE_CURRENT_SOURCE_DIR}/orb_impl.h
                ${CMAKE_CURRENT_SOURCE_DIR}/orb_params.cc
                ${CMAKE_CURRENT_SOURCE_DIR}/orb_extractor.cc
-               ${CMAKE_CURRENT_SOURCE_DIR}/orb_extractor_node.cc)
+               ${CMAKE_CURRENT_SOURCE_DIR}/orb_extractor_node.cc
+               ${CMAKE_CURRENT_SOURCE_DIR}/orb_impl.cc)
 
 # Install headers
 file(GLOB HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/*.h")

--- a/src/stella_vslam/feature/orb_extractor.cc
+++ b/src/stella_vslam/feature/orb_extractor.cc
@@ -299,7 +299,7 @@ std::vector<cv::KeyPoint> orb_extractor::distribute_keypoints_via_tree(const std
 
         // Fork node and remove the old one from nodes
         while (iter != nodes.end()) {
-            if (iter->is_leaf_node_) {
+            if (iter->keypts_.size() == 1) {
                 iter++;
                 continue;
             }
@@ -433,8 +433,6 @@ std::list<orb_extractor_node> orb_extractor::initialize_nodes(const std::vector<
             iter = nodes.erase(iter);
             continue;
         }
-        // Set the leaf node flag if the node has only one keypoint
-        iter->is_leaf_node_ = (iter->keypts_.size() == 1);
         iter++;
     }
 

--- a/src/stella_vslam/feature/orb_extractor.cc
+++ b/src/stella_vslam/feature/orb_extractor.cc
@@ -1,41 +1,4 @@
-/*******************************************************************************
-
-                          License Agreement
-               For Open Source Computer Vision Library
-                       (3-clause BSD License)
-
-Copyright (C) 2009, Willow Garage Inc., all rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-  * Redistributions of source code must retain the above copyright notice,
-    this list of conditions and the following disclaimer.
-
-  * Redistributions in binary form must reproduce the above copyright notice,
-    this list of conditions and the following disclaimer in the documentation
-    and/or other materials provided with the distribution.
-
-  * Neither the names of the copyright holders nor the names of the contributors
-    may be used to endorse or promote products derived from this software
-    without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-*******************************************************************************/
-
 #include "stella_vslam/feature/orb_extractor.h"
-#include "stella_vslam/feature/orb_point_pairs.h"
-#include "stella_vslam/util/trigonometric.h"
 #include "stella_vslam/type.h"
 
 #include <opencv2/core/mat.hpp>
@@ -43,15 +6,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <opencv2/imgproc.hpp>
 #include <opencv2/features2d.hpp>
 
-#ifdef USE_SSE_ORB
-#ifdef _MSC_VER
-#include <intrin.h>
-#else
-#include <x86intrin.h>
-#endif
-#endif // USE_SSE_ORB
-
 #include <iostream>
+
+#include <spdlog/spdlog.h>
 
 namespace stella_vslam {
 namespace feature {
@@ -167,21 +124,6 @@ void orb_extractor::initialize() {
         desired_num_keypts_per_scale *= 1.0 / orb_params_->scale_factor_;
     }
     num_keypts_per_level_.at(orb_params_->num_levels_ - 1) = std::max(static_cast<int>(max_num_keypts_) - static_cast<int>(total_num_keypts), 0);
-
-    // Preparate  for computation of orientation
-    u_max_.resize(fast_half_patch_size_ + 1);
-    const unsigned int vmax = std::floor(fast_half_patch_size_ * std::sqrt(2.0) / 2 + 1);
-    const unsigned int vmin = std::ceil(fast_half_patch_size_ * std::sqrt(2.0) / 2);
-    for (unsigned int v = 0; v <= vmax; ++v) {
-        u_max_.at(v) = std::round(std::sqrt(fast_half_patch_size_ * fast_half_patch_size_ - v * v));
-    }
-    for (unsigned int v = fast_half_patch_size_, v0 = 0; vmin <= v; --v) {
-        while (u_max_.at(v0) == u_max_.at(v0 + 1)) {
-            ++v0;
-        }
-        u_max_.at(v) = v0;
-        ++v0;
-    }
 }
 
 void orb_extractor::create_rectangle_mask(const unsigned int cols, const unsigned int rows) {
@@ -314,9 +256,10 @@ void orb_extractor::compute_fast_keypoints(std::vector<std::vector<cv::KeyPoint>
         keypts_at_level = distribute_keypoints_via_tree(keypts_to_distribute,
                                                         min_border_x, max_border_x, min_border_y, max_border_y,
                                                         num_keypts_per_level_.at(level));
+        SPDLOG_TRACE("keypts_at_level {} filtered={} raw={} desired={}", level, keypts_at_level.size(), keypts_to_distribute.size(), num_keypts_per_level_.at(level));
 
         // Keypoint size is patch size modified by the scale factor
-        const unsigned int scaled_patch_size = fast_patch_size_ * orb_params_->scale_factors_.at(level);
+        const unsigned int scaled_patch_size = orb_impl_.fast_patch_size_ * orb_params_->scale_factors_.at(level);
 
         for (auto& keypt : keypts_at_level) {
             // Translation correction (scale will be corrected after ORB description)
@@ -554,28 +497,7 @@ void orb_extractor::correct_keypoint_scale(std::vector<cv::KeyPoint>& keypts_at_
 }
 
 float orb_extractor::ic_angle(const cv::Mat& image, const cv::Point2f& point) const {
-    int m_01 = 0, m_10 = 0;
-
-    const uchar* const center = &image.at<uchar>(cvRound(point.y), cvRound(point.x));
-
-    for (int u = -fast_half_patch_size_; u <= fast_half_patch_size_; ++u) {
-        m_10 += u * center[u];
-    }
-
-    const auto step = static_cast<int>(image.step1());
-    for (int v = 1; v <= fast_half_patch_size_; ++v) {
-        int v_sum = 0;
-        const int d = u_max_.at(v);
-        for (int u = -d; u <= d; ++u) {
-            const int val_plus = center[u + v * step];
-            const int val_minus = center[u - v * step];
-            v_sum += (val_plus - val_minus);
-            m_10 += u * (val_plus + val_minus);
-        }
-        m_01 += v * v_sum;
-    }
-
-    return cv::fastAtan2(m_01, m_10);
+    return orb_impl_.ic_angle(image, point);
 }
 
 void orb_extractor::compute_orb_descriptors(const cv::Mat& image, const std::vector<cv::KeyPoint>& keypts, cv::Mat& descriptors) const {
@@ -587,66 +509,7 @@ void orb_extractor::compute_orb_descriptors(const cv::Mat& image, const std::vec
 }
 
 void orb_extractor::compute_orb_descriptor(const cv::KeyPoint& keypt, const cv::Mat& image, uchar* desc) const {
-    const float angle = keypt.angle * M_PI / 180.0;
-    const float cos_angle = util::cos(angle);
-    const float sin_angle = util::sin(angle);
-
-    const uchar* const center = &image.at<uchar>(cvRound(keypt.pt.y), cvRound(keypt.pt.x));
-    const auto step = static_cast<int>(image.step);
-
-#ifdef USE_SSE_ORB
-#if !((defined _MSC_VER && defined _M_X64)                            \
-      || (defined __GNUC__ && defined __x86_64__ && defined __SSE3__) \
-      || CV_SSE3)
-#error "The processor is not compatible with SSE. Please configure the CMake with -DUSE_SSE_ORB=OFF."
-#endif
-
-    const __m128 _trig1 = _mm_set_ps(cos_angle, sin_angle, cos_angle, sin_angle);
-    const __m128 _trig2 = _mm_set_ps(-sin_angle, cos_angle, -sin_angle, cos_angle);
-    __m128 _point_pairs;
-    __m128 _mul1;
-    __m128 _mul2;
-    __m128 _vs;
-    __m128i _vi;
-    alignas(16) int32_t ii[4];
-
-#define COMPARE_ORB_POINTS(shift)                          \
-    (_point_pairs = _mm_load_ps(orb_point_pairs + shift),  \
-     _mul1 = _mm_mul_ps(_point_pairs, _trig1),             \
-     _mul2 = _mm_mul_ps(_point_pairs, _trig2),             \
-     _vs = _mm_hadd_ps(_mul1, _mul2),                      \
-     _vi = _mm_cvtps_epi32(_vs),                           \
-     _mm_store_si128(reinterpret_cast<__m128i*>(ii), _vi), \
-     center[ii[0] * step + ii[2]] < center[ii[1] * step + ii[3]])
-
-#else
-
-#define GET_VALUE(shift)                                                                                        \
-    (center[cvRound(*(orb_point_pairs + shift) * sin_angle + *(orb_point_pairs + shift + 1) * cos_angle) * step \
-            + cvRound(*(orb_point_pairs + shift) * cos_angle - *(orb_point_pairs + shift + 1) * sin_angle)])
-
-#define COMPARE_ORB_POINTS(shift) \
-    (GET_VALUE(shift) < GET_VALUE(shift + 2))
-
-#endif
-
-    // interval: (X, Y) x 2 points x 8 pairs = 32
-    static constexpr unsigned interval = 32;
-
-    for (unsigned int i = 0; i < orb_point_pairs_size / interval; ++i) {
-        int32_t val = COMPARE_ORB_POINTS(i * interval);
-        val |= COMPARE_ORB_POINTS(i * interval + 4) << 1;
-        val |= COMPARE_ORB_POINTS(i * interval + 8) << 2;
-        val |= COMPARE_ORB_POINTS(i * interval + 12) << 3;
-        val |= COMPARE_ORB_POINTS(i * interval + 16) << 4;
-        val |= COMPARE_ORB_POINTS(i * interval + 20) << 5;
-        val |= COMPARE_ORB_POINTS(i * interval + 24) << 6;
-        val |= COMPARE_ORB_POINTS(i * interval + 28) << 7;
-        desc[i] = static_cast<uchar>(val);
-    }
-
-#undef GET_VALUE
-#undef COMPARE_ORB_POINTS
+    orb_impl_.compute_orb_descriptor(keypt, image, desc);
 }
 
 } // namespace feature

--- a/src/stella_vslam/feature/orb_extractor.h
+++ b/src/stella_vslam/feature/orb_extractor.h
@@ -27,12 +27,6 @@ public:
     void extract(const cv::_InputArray& in_image, const cv::_InputArray& in_image_mask,
                  std::vector<cv::KeyPoint>& keypts, const cv::_OutputArray& out_descriptors);
 
-    //! Get the maximum number of keypoints
-    unsigned int get_max_num_keypoints() const;
-
-    //! Set the maximum number of keypoints
-    void set_max_num_keypoints(const unsigned int max_num_keypts);
-
     //! parameters for ORB extraction
     const orb_params* orb_params_;
 
@@ -44,9 +38,6 @@ public:
     std::vector<cv::Mat> image_pyramid_;
 
 private:
-    //! Compute the desired number of keypoints per scale
-    std::vector<unsigned int> compute_num_keypts_per_level(unsigned int num_keypts);
-
     //! Calculate scale factors and sigmas
     void calc_scale_factors();
 
@@ -61,12 +52,12 @@ private:
 
     //! Pick computed keypoints on the image uniformly
     std::vector<cv::KeyPoint> distribute_keypoints_via_tree(const std::vector<cv::KeyPoint>& keypts_to_distribute,
-                                                            const int min_x, const int max_x, const int min_y, const int max_y,
-                                                            const unsigned int num_keypts) const;
+                                                            int min_x, int max_x, int min_y, int max_y,
+                                                            float inv_scale_factor) const;
 
     //! Initialize nodes that used for keypoint distribution tree
     std::list<orb_extractor_node> initialize_nodes(const std::vector<cv::KeyPoint>& keypts_to_distribute,
-                                                   const int min_x, const int max_x, const int min_y, const int max_y) const;
+                                                   int min_x, int max_x, int min_y, int max_y) const;
 
     //! Assign child nodes to the all node list
     void assign_child_nodes(const std::array<orb_extractor_node, 4>& child_nodes, std::list<orb_extractor_node>& nodes,
@@ -90,8 +81,8 @@ private:
     //! Compute orb descriptor of a keypoint
     void compute_orb_descriptor(const cv::KeyPoint& keypt, const cv::Mat& image, uchar* desc) const;
 
-    //! Number of feature points to be extracted
-    unsigned int max_num_keypts_;
+    //! Size of node occupied by one feature point
+    unsigned int min_size_;
 
     //! size of maximum ORB patch radius
     static constexpr unsigned int orb_patch_radius_ = 19;
@@ -99,9 +90,6 @@ private:
     //! rectangle mask has been already initialized or not
     bool mask_is_initialized_ = false;
     cv::Mat rect_mask_;
-
-    //! Maximum number of keypoint of each level
-    std::vector<unsigned int> num_keypts_per_level_;
 
     orb_impl orb_impl_;
 };

--- a/src/stella_vslam/feature/orb_extractor.h
+++ b/src/stella_vslam/feature/orb_extractor.h
@@ -3,6 +3,7 @@
 
 #include "stella_vslam/feature/orb_params.h"
 #include "stella_vslam/feature/orb_extractor_node.h"
+#include "stella_vslam/feature/orb_impl.h"
 
 #include <opencv2/core/mat.hpp>
 #include <opencv2/core/types.hpp>
@@ -92,11 +93,6 @@ private:
     //! Number of feature points to be extracted
     unsigned int max_num_keypts_;
 
-    //! BRIEF orientation
-    static constexpr unsigned int fast_patch_size_ = 31;
-    //! half size of FAST patch
-    static constexpr int fast_half_patch_size_ = fast_patch_size_ / 2;
-
     //! size of maximum ORB patch radius
     static constexpr unsigned int orb_patch_radius_ = 19;
 
@@ -106,8 +102,8 @@ private:
 
     //! Maximum number of keypoint of each level
     std::vector<unsigned int> num_keypts_per_level_;
-    //! Index limitation that used for calculating of keypoint orientation
-    std::vector<int> u_max_;
+
+    orb_impl orb_impl_;
 };
 
 } // namespace feature

--- a/src/stella_vslam/feature/orb_extractor.h
+++ b/src/stella_vslam/feature/orb_extractor.h
@@ -44,8 +44,8 @@ public:
     std::vector<cv::Mat> image_pyramid_;
 
 private:
-    //! Initialize orb extractor
-    void initialize();
+    //! Compute the desired number of keypoints per scale
+    std::vector<unsigned int> compute_num_keypts_per_level(unsigned int num_keypts);
 
     //! Calculate scale factors and sigmas
     void calc_scale_factors();

--- a/src/stella_vslam/feature/orb_extractor_node.h
+++ b/src/stella_vslam/feature/orb_extractor_node.h
@@ -26,9 +26,6 @@ public:
 
     //! A iterator pointing to self, used for removal on list
     std::list<orb_extractor_node>::iterator iter_;
-
-    //! A flag designating if this node is a leaf node
-    bool is_leaf_node_ = false;
 };
 
 } // namespace feature

--- a/src/stella_vslam/feature/orb_extractor_node.h
+++ b/src/stella_vslam/feature/orb_extractor_node.h
@@ -18,6 +18,11 @@ public:
     //! Divide node to four child nodes
     std::array<orb_extractor_node, 4> divide_node();
 
+    //! Size of area
+    unsigned int size() const {
+        return (pt_end_.x - pt_begin_.x) * (pt_end_.y - pt_begin_.y);
+    }
+
     //! Keypoints which distributed into this node
     std::vector<cv::KeyPoint> keypts_;
 

--- a/src/stella_vslam/feature/orb_impl.cc
+++ b/src/stella_vslam/feature/orb_impl.cc
@@ -1,0 +1,156 @@
+/*******************************************************************************
+
+                          License Agreement
+               For Open Source Computer Vision Library
+                       (3-clause BSD License)
+
+Copyright (C) 2009, Willow Garage Inc., all rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+  * Neither the names of the copyright holders nor the names of the contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*******************************************************************************/
+
+#include "stella_vslam/feature/orb_impl.h"
+#include "stella_vslam/feature/orb_point_pairs.h"
+#include "stella_vslam/util/trigonometric.h"
+
+#ifdef USE_SSE_ORB
+#ifdef _MSC_VER
+#include <intrin.h>
+#else
+#include <x86intrin.h>
+#endif
+#endif // USE_SSE_ORB
+
+namespace stella_vslam {
+namespace feature {
+
+orb_impl::orb_impl() {
+    // Preparate  for computation of orientation
+    u_max_.resize(fast_half_patch_size_ + 1);
+    const unsigned int vmax = std::floor(fast_half_patch_size_ * std::sqrt(2.0) / 2 + 1);
+    const unsigned int vmin = std::ceil(fast_half_patch_size_ * std::sqrt(2.0) / 2);
+    for (unsigned int v = 0; v <= vmax; ++v) {
+        u_max_.at(v) = std::round(std::sqrt(fast_half_patch_size_ * fast_half_patch_size_ - v * v));
+    }
+    for (unsigned int v = fast_half_patch_size_, v0 = 0; vmin <= v; --v) {
+        while (u_max_.at(v0) == u_max_.at(v0 + 1)) {
+            ++v0;
+        }
+        u_max_.at(v) = v0;
+        ++v0;
+    }
+}
+
+float orb_impl::ic_angle(const cv::Mat& image, const cv::Point2f& point) const {
+    int m_01 = 0, m_10 = 0;
+
+    const uchar* const center = &image.at<uchar>(cvRound(point.y), cvRound(point.x));
+
+    for (int u = -fast_half_patch_size_; u <= fast_half_patch_size_; ++u) {
+        m_10 += u * center[u];
+    }
+
+    const auto step = static_cast<int>(image.step1());
+    for (int v = 1; v <= fast_half_patch_size_; ++v) {
+        int v_sum = 0;
+        const int d = u_max_.at(v);
+        for (int u = -d; u <= d; ++u) {
+            const int val_plus = center[u + v * step];
+            const int val_minus = center[u - v * step];
+            v_sum += (val_plus - val_minus);
+            m_10 += u * (val_plus + val_minus);
+        }
+        m_01 += v * v_sum;
+    }
+
+    return cv::fastAtan2(m_01, m_10);
+}
+
+void orb_impl::compute_orb_descriptor(const cv::KeyPoint& keypt, const cv::Mat& image, uchar* desc) const {
+    const float angle = keypt.angle * M_PI / 180.0;
+    const float cos_angle = util::cos(angle);
+    const float sin_angle = util::sin(angle);
+
+    const uchar* const center = &image.at<uchar>(cvRound(keypt.pt.y), cvRound(keypt.pt.x));
+    const auto step = static_cast<int>(image.step);
+
+#ifdef USE_SSE_ORB
+#if !((defined _MSC_VER && defined _M_X64)                            \
+      || (defined __GNUC__ && defined __x86_64__ && defined __SSE3__) \
+      || CV_SSE3)
+#error "The processor is not compatible with SSE. Please configure the CMake with -DUSE_SSE_ORB=OFF."
+#endif
+
+    const __m128 _trig1 = _mm_set_ps(cos_angle, sin_angle, cos_angle, sin_angle);
+    const __m128 _trig2 = _mm_set_ps(-sin_angle, cos_angle, -sin_angle, cos_angle);
+    __m128 _point_pairs;
+    __m128 _mul1;
+    __m128 _mul2;
+    __m128 _vs;
+    __m128i _vi;
+    alignas(16) int32_t ii[4];
+
+#define COMPARE_ORB_POINTS(shift)                          \
+    (_point_pairs = _mm_load_ps(orb_point_pairs + shift),  \
+     _mul1 = _mm_mul_ps(_point_pairs, _trig1),             \
+     _mul2 = _mm_mul_ps(_point_pairs, _trig2),             \
+     _vs = _mm_hadd_ps(_mul1, _mul2),                      \
+     _vi = _mm_cvtps_epi32(_vs),                           \
+     _mm_store_si128(reinterpret_cast<__m128i*>(ii), _vi), \
+     center[ii[0] * step + ii[2]] < center[ii[1] * step + ii[3]])
+
+#else
+
+#define GET_VALUE(shift)                                                                                        \
+    (center[cvRound(*(orb_point_pairs + shift) * sin_angle + *(orb_point_pairs + shift + 1) * cos_angle) * step \
+            + cvRound(*(orb_point_pairs + shift) * cos_angle - *(orb_point_pairs + shift + 1) * sin_angle)])
+
+#define COMPARE_ORB_POINTS(shift) \
+    (GET_VALUE(shift) < GET_VALUE(shift + 2))
+
+#endif
+
+    // interval: (X, Y) x 2 points x 8 pairs = 32
+    static constexpr unsigned interval = 32;
+
+    for (unsigned int i = 0; i < orb_point_pairs_size / interval; ++i) {
+        int32_t val = COMPARE_ORB_POINTS(i * interval);
+        val |= COMPARE_ORB_POINTS(i * interval + 4) << 1;
+        val |= COMPARE_ORB_POINTS(i * interval + 8) << 2;
+        val |= COMPARE_ORB_POINTS(i * interval + 12) << 3;
+        val |= COMPARE_ORB_POINTS(i * interval + 16) << 4;
+        val |= COMPARE_ORB_POINTS(i * interval + 20) << 5;
+        val |= COMPARE_ORB_POINTS(i * interval + 24) << 6;
+        val |= COMPARE_ORB_POINTS(i * interval + 28) << 7;
+        desc[i] = static_cast<uchar>(val);
+    }
+
+#undef GET_VALUE
+#undef COMPARE_ORB_POINTS
+}
+} // namespace feature
+} // namespace stella_vslam

--- a/src/stella_vslam/feature/orb_impl.h
+++ b/src/stella_vslam/feature/orb_impl.h
@@ -1,0 +1,29 @@
+#ifndef STELLA_VSLAM_FEATURE_ORB_IMPL_H
+#define STELLA_VSLAM_FEATURE_ORB_IMPL_H
+
+#include <opencv2/core/mat.hpp>
+#include <opencv2/core/types.hpp>
+
+namespace stella_vslam {
+namespace feature {
+
+class orb_impl {
+public:
+    orb_impl();
+    float ic_angle(const cv::Mat& image, const cv::Point2f& point) const;
+    void compute_orb_descriptor(const cv::KeyPoint& keypt, const cv::Mat& image, uchar* desc) const;
+
+    //! BRIEF orientation
+    static constexpr unsigned int fast_patch_size_ = 31;
+    //! half size of FAST patch
+    static constexpr int fast_half_patch_size_ = fast_patch_size_ / 2;
+
+private:
+    //! Index limitation that used for calculating of keypoint orientation
+    std::vector<int> u_max_;
+};
+
+} // namespace feature
+} // namespace stella_vslam
+
+#endif // STELLA_VSLAM_FEATURE_ORB_IMPL_H


### PR DESCRIPTION
This change removes the resolution-dependent parameters `Preprocessing::max_num_keypoints` and `Preprocessing::ini_max_num_keypoints`, and adds a resolution-independent `Preprocessing::min_size` parameter.