### PR TITLE
Allow multiple root nodes

### DIFF
--- a/src/stella_vslam/data/graph_node.cc
+++ b/src/stella_vslam/data/graph_node.cc
@@ -438,6 +438,22 @@ void graph_node::set_spanning_root(std::shared_ptr<keyframe>& keyfrm) {
     spanning_root_ = keyfrm;
 }
 
+std::vector<std::shared_ptr<keyframe>> graph_node::get_keyframes_from_root() {
+    std::vector<std::shared_ptr<keyframe>> keyfrms;
+    std::list<std::shared_ptr<data::keyframe>> keyfrms_to_check;
+    keyfrms_to_check.push_back(get_spanning_root());
+    while (!keyfrms_to_check.empty()) {
+        auto parent = keyfrms_to_check.front();
+        keyfrms.push_back(parent);
+        const auto children = parent->graph_node_->get_spanning_children();
+        for (auto child : children) {
+            keyfrms_to_check.push_back(child);
+        }
+        keyfrms_to_check.pop_front();
+    }
+    return keyfrms;
+}
+
 template<typename T, typename U>
 std::vector<std::shared_ptr<keyframe>> graph_node::extract_intersection(const T& keyfrms_1, const U& keyfrms_2) {
     std::vector<std::shared_ptr<keyframe>> intersection;

--- a/src/stella_vslam/data/graph_node.cc
+++ b/src/stella_vslam/data/graph_node.cc
@@ -14,7 +14,7 @@ namespace stella_vslam {
 namespace data {
 
 graph_node::graph_node(std::shared_ptr<keyframe>& keyfrm)
-    : owner_keyfrm_(keyfrm), has_spanning_parent_(false) {}
+    : owner_keyfrm_(keyfrm) {}
 
 void graph_node::add_connection(const std::shared_ptr<keyframe>& keyfrm, const unsigned int num_shared_lms) {
     std::lock_guard<std::mutex> lock(mtx_);
@@ -82,7 +82,7 @@ void graph_node::update_connections(unsigned int min_num_shared_lms) {
             auto keyfrm = obs.first;
             auto locked_keyfrm = keyfrm.lock();
 
-            if (!locked_keyfrm->graph_node_->has_spanning_parent_ && locked_keyfrm->id_ != 0) {
+            if (locked_keyfrm->graph_node_->spanning_parent_.expired() && !locked_keyfrm->graph_node_->is_spanning_root()) {
                 continue;
             }
             if (locked_keyfrm->id_ == owner_keyfrm->id_) {
@@ -150,12 +150,12 @@ void graph_node::update_connections(unsigned int min_num_shared_lms) {
         ordered_covisibilities_ = ordered_covisibilities;
         ordered_num_shared_lms_ = ordered_num_shared_lms;
 
-        if (!has_spanning_parent_ && owner_keyfrm->id_ != 0) {
+        if (spanning_parent_.expired() && !is_spanning_root_impl()) {
             // set the parent of spanning tree
             assert(nearest_covisibility->id_ == ordered_covisibilities.front().lock()->id_);
             spanning_parent_ = nearest_covisibility;
+            spanning_root_ = spanning_parent_.lock()->graph_node_->get_spanning_root_impl();
             nearest_covisibility->graph_node_->add_spanning_child(owner_keyfrm);
-            has_spanning_parent_ = true;
         }
     }
 }
@@ -274,14 +274,10 @@ unsigned int graph_node::get_num_shared_landmarks(const std::shared_ptr<keyframe
 }
 
 void graph_node::set_spanning_parent(const std::shared_ptr<keyframe>& keyfrm) {
+    // NOTE: keyfrm can be nullptr
     std::lock_guard<std::mutex> lock(mtx_);
-    assert(!has_spanning_parent_);
+    assert(spanning_parent_.expired());
     spanning_parent_ = keyfrm;
-    has_spanning_parent_ = true;
-}
-
-bool graph_node::has_spanning_parent() const {
-    return has_spanning_parent_;
 }
 
 std::shared_ptr<keyframe> graph_node::get_spanning_parent() const {
@@ -401,6 +397,45 @@ std::set<std::shared_ptr<keyframe>> graph_node::get_loop_edges() const {
 bool graph_node::has_loop_edge() const {
     std::lock_guard<std::mutex> lock(mtx_);
     return !loop_edges_.empty();
+}
+
+std::shared_ptr<keyframe> graph_node::get_spanning_root() {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return get_spanning_root_impl();
+}
+
+std::shared_ptr<keyframe> graph_node::get_spanning_root_impl() {
+    auto spanning_root = spanning_root_.lock();
+    if (spanning_root) {
+        return spanning_root;
+    }
+    else {
+        auto spanning_parent = spanning_parent_.lock();
+        if (spanning_parent) {
+            spanning_root_ = spanning_parent->graph_node_->get_spanning_root_impl();
+        }
+        else {
+            spanning_root_ = owner_keyfrm_.lock();
+        }
+        return spanning_root_.lock();
+    }
+}
+
+bool graph_node::is_spanning_root() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return is_spanning_root_impl();
+}
+
+bool graph_node::is_spanning_root_impl() const {
+    auto spanning_root = spanning_root_.lock();
+    auto owner_keyfrm = owner_keyfrm_.lock();
+    assert(owner_keyfrm);
+    return spanning_root && spanning_root->id_ == owner_keyfrm->id_;
+}
+
+void graph_node::set_spanning_root(std::shared_ptr<keyframe>& keyfrm) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    spanning_root_ = keyfrm;
 }
 
 template<typename T, typename U>

--- a/src/stella_vslam/data/graph_node.h
+++ b/src/stella_vslam/data/graph_node.h
@@ -89,11 +89,6 @@ public:
     void set_spanning_parent(const std::shared_ptr<keyframe>& keyfrm);
 
     /**
-     * Whether this node has the parent or not
-     */
-    bool has_spanning_parent() const;
-
-    /**
      * Get the parent of spanning tree
      */
     std::shared_ptr<keyframe> get_spanning_parent() const;
@@ -146,6 +141,15 @@ public:
      */
     bool has_loop_edge() const;
 
+    //-----------------------------------------
+    // root
+
+    std::shared_ptr<keyframe> get_spanning_root();
+
+    bool is_spanning_root() const;
+
+    void set_spanning_root(std::shared_ptr<keyframe>& keyfrm);
+
 private:
     /**
      * Update the order of the covisibilities (without mutex)
@@ -158,6 +162,13 @@ private:
      */
     template<typename T, typename U>
     static std::vector<std::shared_ptr<keyframe>> extract_intersection(const T& keyfrms_1, const U& keyfrms_2);
+
+    //-----------------------------------------
+    // implementation
+
+    std::shared_ptr<keyframe> get_spanning_root_impl();
+
+    bool is_spanning_root_impl() const;
 
     //! keyframe of this node
     std::weak_ptr<keyframe> const owner_keyfrm_;
@@ -174,8 +185,8 @@ private:
     std::weak_ptr<keyframe> spanning_parent_;
     //! children of spanning tree
     id_ordered_set<std::weak_ptr<keyframe>> spanning_children_;
-    //! flag which indicates spanning tree is not set yet or not
-    std::atomic<bool> has_spanning_parent_;
+    //! root keyframe of spanning tree
+    std::weak_ptr<keyframe> spanning_root_;
 
     //! loop edges
     id_ordered_set<std::weak_ptr<keyframe>> loop_edges_;

--- a/src/stella_vslam/data/graph_node.h
+++ b/src/stella_vslam/data/graph_node.h
@@ -84,7 +84,7 @@ public:
 
     /**
      * Set the parent node of spanning tree
-     * (NOTE: this functions will be only used for map loading)
+     * (NOTE: this functions will be only used for map loading or initialization)
      */
     void set_spanning_parent(const std::shared_ptr<keyframe>& keyfrm);
 
@@ -149,6 +149,8 @@ public:
     bool is_spanning_root() const;
 
     void set_spanning_root(std::shared_ptr<keyframe>& keyfrm);
+
+    std::vector<std::shared_ptr<keyframe>> get_keyframes_from_root();
 
 private:
     /**

--- a/src/stella_vslam/data/keyframe.cc
+++ b/src/stella_vslam/data/keyframe.cc
@@ -340,8 +340,8 @@ void keyframe::set_to_be_erased() {
 }
 
 void keyframe::prepare_for_erasing(map_database* map_db, bow_database* bow_db) {
-    // cannot erase the origin
-    if (*this == *(map_db->origin_keyfrm_)) {
+    if (graph_node_->is_spanning_root()) {
+        spdlog::warn("cannot erase the root node: {}", id_);
         return;
     }
 

--- a/src/stella_vslam/data/map_database.h
+++ b/src/stella_vslam/data/map_database.h
@@ -244,9 +244,6 @@ public:
      */
     bool to_db(sqlite3* db) const;
 
-    //! origin keyframe
-    std::shared_ptr<keyframe> origin_keyfrm_ = nullptr;
-
     //! mutex for locking ALL access to the database
     //! (NOTE: cannot used in map_database class)
     static std::mutex mtx_database_;

--- a/src/stella_vslam/data/map_database.h
+++ b/src/stella_vslam/data/map_database.h
@@ -103,6 +103,7 @@ public:
 
     /**
      * Get all of the keyframes in the database
+     * NOTE: Access multiple spanning trees. Used only to read and write databases.
      * @return
      */
     std::vector<std::shared_ptr<keyframe>> get_all_keyframes() const;
@@ -166,6 +167,16 @@ public:
      * @return marker
      */
     std::shared_ptr<marker> get_marker(unsigned int id) const;
+
+    /**
+     * Add spanning root
+     */
+    void add_spanning_root(std::shared_ptr<keyframe>& keyframe);
+
+    /**
+     * Get spanning roots
+     */
+    std::vector<std::shared_ptr<keyframe>> get_spanning_roots();
 
     /**
      * Get the number of landmarks
@@ -311,6 +322,9 @@ private:
     std::unordered_map<unsigned int, std::shared_ptr<landmark>> landmarks_;
     //! IDs and markers
     std::unordered_map<unsigned int, std::shared_ptr<marker>> markers_;
+
+    //! spanning roots
+    std::vector<std::shared_ptr<keyframe>> spanning_roots_;
 
     //! The last keyframe added to the database
     std::shared_ptr<keyframe> last_inserted_keyfrm_ = nullptr;

--- a/src/stella_vslam/global_optimization_module.cc
+++ b/src/stella_vslam/global_optimization_module.cc
@@ -18,7 +18,7 @@ global_optimization_module::global_optimization_module(data::map_database* map_d
     : loop_detector_(new module::loop_detector(bow_db, bow_vocab, util::yaml_optional_ref(yaml_node, "LoopDetector"), fix_scale)),
       loop_bundle_adjuster_(new module::loop_bundle_adjuster(map_db)),
       map_db_(map_db),
-      graph_optimizer_(new optimize::graph_optimizer(map_db, fix_scale)) {
+      graph_optimizer_(new optimize::graph_optimizer(fix_scale)) {
     spdlog::debug("CONSTRUCT: global_optimization_module");
 }
 

--- a/src/stella_vslam/global_optimization_module.cc
+++ b/src/stella_vslam/global_optimization_module.cc
@@ -209,6 +209,11 @@ void global_optimization_module::correct_loop() {
 
     spdlog::info("detect loop: keyframe {} - keyframe {}", final_candidate_keyfrm->id_, cur_keyfrm_->id_);
 
+    if (cur_keyfrm_->graph_node_->get_spanning_root() != final_candidate_keyfrm->graph_node_->get_spanning_root()) {
+        spdlog::warn("The feature to merge two spanning trees has not yet been implemented.");
+        return;
+    }
+
     // 0. pre-processing
 
     // 0-1. stop the mapping module and the previous loop bundle adjuster

--- a/src/stella_vslam/global_optimization_module.cc
+++ b/src/stella_vslam/global_optimization_module.cc
@@ -196,9 +196,7 @@ void global_optimization_module::run() {
 
 void global_optimization_module::queue_keyframe(const std::shared_ptr<data::keyframe>& keyfrm) {
     std::lock_guard<std::mutex> lock(mtx_keyfrm_queue_);
-    if (keyfrm->id_ != 0) {
-        keyfrms_queue_.push_back(keyfrm);
-    }
+    keyfrms_queue_.push_back(keyfrm);
 }
 
 bool global_optimization_module::keyframe_is_queued() const {
@@ -291,7 +289,7 @@ void global_optimization_module::correct_loop() {
         thread_for_loop_BA_.reset(nullptr);
     }
     SPDLOG_TRACE("global_optimization_module: launch loop BA");
-    thread_for_loop_BA_ = std::unique_ptr<std::thread>(new std::thread(&module::loop_bundle_adjuster::optimize, loop_bundle_adjuster_.get()));
+    thread_for_loop_BA_ = std::unique_ptr<std::thread>(new std::thread(&module::loop_bundle_adjuster::optimize, loop_bundle_adjuster_.get(), cur_keyfrm_));
 
     // 6. post-processing
 

--- a/src/stella_vslam/io/trajectory_io.cc
+++ b/src/stella_vslam/io/trajectory_io.cc
@@ -116,7 +116,12 @@ void trajectory_io::save_keyframe_trajectory(const std::string& path, const std:
     // 1. acquire keyframes and sort them
 
     assert(map_db_);
-    auto keyfrms = map_db_->get_all_keyframes();
+    auto roots = map_db_->get_spanning_roots();
+    if (roots.empty()) {
+        spdlog::warn("empty map");
+        return;
+    }
+    auto keyfrms = roots.back()->graph_node_->get_keyframes_from_root();
     std::sort(keyfrms.begin(), keyfrms.end(), [&](const std::shared_ptr<data::keyframe>& keyfrm_1, const std::shared_ptr<data::keyframe>& keyfrm_2) {
         return *keyfrm_1 < *keyfrm_2;
     });

--- a/src/stella_vslam/mapping_module.cc
+++ b/src/stella_vslam/mapping_module.cc
@@ -110,7 +110,9 @@ void mapping_module::run() {
         // create and extend the map with the new keyframe
         mapping_with_new_keyframe();
         // send the new keyframe to the global optimization module
-        global_optimizer_->queue_keyframe(cur_keyfrm_);
+        if (!cur_keyfrm_->graph_node_->is_spanning_root()) {
+            global_optimizer_->queue_keyframe(cur_keyfrm_);
+        }
     }
 
     spdlog::info("terminate mapping module");

--- a/src/stella_vslam/module/initializer.cc
+++ b/src/stella_vslam/module/initializer.cc
@@ -194,6 +194,8 @@ bool initializer::create_map_for_monocular(data::bow_vocabulary* bow_vocab, data
     // create initial keyframes
     auto init_keyfrm = data::keyframe::make_keyframe(map_db_->next_keyframe_id_++, init_frm_);
     auto curr_keyfrm = data::keyframe::make_keyframe(map_db_->next_keyframe_id_++, curr_frm);
+    curr_keyfrm->graph_node_->set_spanning_parent(init_keyfrm);
+    init_keyfrm->graph_node_->add_spanning_child(curr_keyfrm);
     init_keyfrm->graph_node_->set_spanning_root(init_keyfrm);
     curr_keyfrm->graph_node_->set_spanning_root(init_keyfrm);
 
@@ -212,6 +214,7 @@ bool initializer::create_map_for_monocular(data::bow_vocabulary* bow_vocab, data
     map_db_->update_frame_statistics(curr_frm, false);
 
     // assign 2D-3D associations
+    std::vector<std::shared_ptr<data::landmark>> lms;
     for (unsigned int init_idx = 0; init_idx < init_matches_.size(); init_idx++) {
         const auto curr_idx = init_matches_.at(init_idx);
         if (curr_idx < 0) {
@@ -235,6 +238,7 @@ bool initializer::create_map_for_monocular(data::bow_vocabulary* bow_vocab, data
 
         // add the landmark to the map DB
         map_db_->add_landmark(lm);
+        lms.push_back(lm);
     }
 
     bool indefinite_scale = true;
@@ -246,7 +250,8 @@ bool initializer::create_map_for_monocular(data::bow_vocabulary* bow_vocab, data
     }
 
     // assign marker associations
-    const auto assign_marker_associations = [this](const std::shared_ptr<data::keyframe>& keyfrm) {
+    std::vector<std::shared_ptr<data::marker>> markers;
+    const auto assign_marker_associations = [this, &markers](const std::shared_ptr<data::keyframe>& keyfrm) {
         for (const auto& id_mkr2d : keyfrm->markers_2d_) {
             auto marker = map_db_->get_marker(id_mkr2d.first);
             if (!marker) {
@@ -255,6 +260,7 @@ bool initializer::create_map_for_monocular(data::bow_vocabulary* bow_vocab, data
                 marker = std::make_shared<data::marker>(corners_pos_w, id_mkr2d.first, mkr2d.marker_model_);
                 // add the marker to the map DB
                 map_db_->add_marker(marker);
+                markers.push_back(marker);
             }
             // Set the association to the new marker
             keyfrm->add_marker(marker);
@@ -265,8 +271,9 @@ bool initializer::create_map_for_monocular(data::bow_vocabulary* bow_vocab, data
     assign_marker_associations(curr_keyfrm);
 
     // global bundle adjustment
-    const auto global_bundle_adjuster = optimize::global_bundle_adjuster(map_db_, num_ba_iters_, true);
-    global_bundle_adjuster.optimize_for_initialization();
+    const auto global_bundle_adjuster = optimize::global_bundle_adjuster(num_ba_iters_, true);
+    std::vector<std::shared_ptr<data::keyframe>> keyfrms{init_keyfrm, curr_keyfrm};
+    global_bundle_adjuster.optimize_for_initialization(keyfrms, lms, markers);
 
     if (indefinite_scale) {
         // scale the map so that the median of depths is 1.0

--- a/src/stella_vslam/module/initializer.cc
+++ b/src/stella_vslam/module/initializer.cc
@@ -198,6 +198,7 @@ bool initializer::create_map_for_monocular(data::bow_vocabulary* bow_vocab, data
     init_keyfrm->graph_node_->add_spanning_child(curr_keyfrm);
     init_keyfrm->graph_node_->set_spanning_root(init_keyfrm);
     curr_keyfrm->graph_node_->set_spanning_root(init_keyfrm);
+    map_db_->add_spanning_root(init_keyfrm);
 
     // compute BoW representations
     init_keyfrm->compute_bow(bow_vocab);
@@ -329,6 +330,7 @@ bool initializer::create_map_for_stereo(data::bow_vocabulary* bow_vocab, data::f
     curr_frm.set_pose_cw(Mat44_t::Identity());
     auto curr_keyfrm = data::keyframe::make_keyframe(map_db_->next_keyframe_id_++, curr_frm);
     curr_keyfrm->graph_node_->set_spanning_root(curr_keyfrm);
+    map_db_->add_spanning_root(curr_keyfrm);
 
     // compute BoW representation
     curr_keyfrm->compute_bow(bow_vocab);

--- a/src/stella_vslam/module/initializer.cc
+++ b/src/stella_vslam/module/initializer.cc
@@ -194,6 +194,8 @@ bool initializer::create_map_for_monocular(data::bow_vocabulary* bow_vocab, data
     // create initial keyframes
     auto init_keyfrm = data::keyframe::make_keyframe(map_db_->next_keyframe_id_++, init_frm_);
     auto curr_keyfrm = data::keyframe::make_keyframe(map_db_->next_keyframe_id_++, curr_frm);
+    init_keyfrm->graph_node_->set_spanning_root(init_keyfrm);
+    curr_keyfrm->graph_node_->set_spanning_root(init_keyfrm);
 
     // compute BoW representations
     init_keyfrm->compute_bow(bow_vocab);
@@ -281,9 +283,6 @@ bool initializer::create_map_for_monocular(data::bow_vocabulary* bow_vocab, data
     // update the current frame pose
     curr_frm.set_pose_cw(curr_keyfrm->get_pose_cw());
 
-    // set the origin keyframe
-    map_db_->origin_keyfrm_ = init_keyfrm;
-
     spdlog::info("new map created with {} points: frame {} - frame {}", map_db_->get_num_landmarks(), init_frm_.id_, curr_frm.id_);
     state_ = initializer_state_t::Succeeded;
     return true;
@@ -322,6 +321,7 @@ bool initializer::create_map_for_stereo(data::bow_vocabulary* bow_vocab, data::f
     // create an initial keyframe
     curr_frm.set_pose_cw(Mat44_t::Identity());
     auto curr_keyfrm = data::keyframe::make_keyframe(map_db_->next_keyframe_id_++, curr_frm);
+    curr_keyfrm->graph_node_->set_spanning_root(curr_keyfrm);
 
     // compute BoW representation
     curr_keyfrm->compute_bow(bow_vocab);
@@ -358,9 +358,6 @@ bool initializer::create_map_for_stereo(data::bow_vocabulary* bow_vocab, data::f
         // add the landmark to the map DB
         map_db_->add_landmark(lm);
     }
-
-    // set the origin keyframe
-    map_db_->origin_keyfrm_ = curr_keyfrm;
 
     spdlog::info("new map created with {} points: frame {}", map_db_->get_num_landmarks(), curr_frm.id_);
     state_ = initializer_state_t::Succeeded;

--- a/src/stella_vslam/module/local_map_cleaner.cc
+++ b/src/stella_vslam/module/local_map_cleaner.cc
@@ -79,8 +79,8 @@ unsigned int local_map_cleaner::remove_redundant_keyframes(const std::shared_ptr
     // check redundancy for each of the covisibilities
     const auto cur_covisibilities = cur_keyfrm->graph_node_->get_top_n_covisibilities(top_n_covisibilities_to_search_);
     for (const auto& covisibility : cur_covisibilities) {
-        // cannot remove the origin
-        if (!covisibility->graph_node_->has_spanning_parent()) {
+        // cannot remove the root node
+        if (covisibility->graph_node_->is_spanning_root()) {
             continue;
         }
         // cannot remove the recent keyframe(s)

--- a/src/stella_vslam/module/loop_bundle_adjuster.cc
+++ b/src/stella_vslam/module/loop_bundle_adjuster.cc
@@ -29,7 +29,7 @@ bool loop_bundle_adjuster::is_running() const {
     return loop_BA_is_running_;
 }
 
-void loop_bundle_adjuster::optimize() {
+void loop_bundle_adjuster::optimize(const std::shared_ptr<data::keyframe>& curr_keyfrm) {
     spdlog::info("start loop bundle adjustment");
 
     {
@@ -68,10 +68,10 @@ void loop_bundle_adjuster::optimize() {
 
         std::lock_guard<std::mutex> lock2(data::map_database::mtx_database_);
 
-        spdlog::debug("update the camera pose along the spanning tree from the origin");
+        spdlog::debug("update the camera pose along the spanning tree from the root");
         eigen_alloc_unord_map<unsigned int, Mat44_t> keyfrm_to_cam_pose_cw_before_BA;
         std::list<std::shared_ptr<data::keyframe>> keyfrms_to_check;
-        keyfrms_to_check.push_back(map_db_->origin_keyfrm_);
+        keyfrms_to_check.push_back(curr_keyfrm->graph_node_->get_spanning_root());
         while (!keyfrms_to_check.empty()) {
             auto parent = keyfrms_to_check.front();
             const Mat44_t cam_pose_wp = parent->get_pose_wc();

--- a/src/stella_vslam/module/loop_bundle_adjuster.cc
+++ b/src/stella_vslam/module/loop_bundle_adjuster.cc
@@ -104,8 +104,27 @@ void loop_bundle_adjuster::optimize(const std::shared_ptr<data::keyframe>& curr_
         }
 
         spdlog::debug("update the positions of the landmarks");
-        const auto landmarks = map_db_->get_all_landmarks();
-        for (const auto& lm : landmarks) {
+        auto keyfrms = curr_keyfrm->graph_node_->get_keyframes_from_root();
+        std::unordered_set<unsigned int> already_found_landmark_ids;
+        std::vector<std::shared_ptr<data::landmark>> lms;
+        for (const auto& keyfrm : keyfrms) {
+            for (const auto& lm : keyfrm->get_landmarks()) {
+                if (!lm) {
+                    continue;
+                }
+                if (lm->will_be_erased()) {
+                    continue;
+                }
+                if (already_found_landmark_ids.count(lm->id_)) {
+                    continue;
+                }
+
+                already_found_landmark_ids.insert(lm->id_);
+                lms.push_back(lm);
+            }
+        }
+
+        for (const auto& lm : lms) {
             if (lm->will_be_erased()) {
                 continue;
             }

--- a/src/stella_vslam/module/loop_bundle_adjuster.cc
+++ b/src/stella_vslam/module/loop_bundle_adjuster.cc
@@ -42,8 +42,9 @@ void loop_bundle_adjuster::optimize(const std::shared_ptr<data::keyframe>& curr_
     std::unordered_set<unsigned int> optimized_landmark_ids;
     eigen_alloc_unord_map<unsigned int, Vec3_t> lm_to_pos_w_after_global_BA;
     eigen_alloc_unord_map<unsigned int, Mat44_t> keyfrm_to_pose_cw_after_global_BA;
-    const auto global_BA = optimize::global_bundle_adjuster(map_db_, num_iter_, false);
-    bool ok = global_BA.optimize(optimized_keyfrm_ids, optimized_landmark_ids,
+    const auto global_BA = optimize::global_bundle_adjuster(num_iter_, false);
+    bool ok = global_BA.optimize(curr_keyfrm->graph_node_->get_keyframes_from_root(),
+                                 optimized_keyfrm_ids, optimized_landmark_ids,
                                  lm_to_pos_w_after_global_BA,
                                  keyfrm_to_pose_cw_after_global_BA, &abort_loop_BA_);
 

--- a/src/stella_vslam/module/loop_bundle_adjuster.h
+++ b/src/stella_vslam/module/loop_bundle_adjuster.h
@@ -8,6 +8,7 @@ namespace stella_vslam {
 class mapping_module;
 
 namespace data {
+class keyframe;
 class map_database;
 } // namespace data
 
@@ -43,7 +44,7 @@ public:
     /**
      * Run loop BA
      */
-    void optimize();
+    void optimize(const std::shared_ptr<data::keyframe>& curr_keyfrm);
 
 private:
     //! map database

--- a/src/stella_vslam/optimize/global_bundle_adjuster.cc
+++ b/src/stella_vslam/optimize/global_bundle_adjuster.cc
@@ -58,7 +58,7 @@ void optimize_impl(g2o::SparseOptimizer& optimizer,
             continue;
         }
 
-        auto keyfrm_vtx = keyfrm_vtx_container.create_vertex(keyfrm, keyfrm->id_ == 0);
+        auto keyfrm_vtx = keyfrm_vtx_container.create_vertex(keyfrm, keyfrm->graph_node_->is_spanning_root());
         optimizer.addVertex(keyfrm_vtx);
     }
 

--- a/src/stella_vslam/optimize/global_bundle_adjuster.h
+++ b/src/stella_vslam/optimize/global_bundle_adjuster.h
@@ -13,21 +13,24 @@ class global_bundle_adjuster {
 public:
     /**
      * Constructor
-     * @param map_db
      * @param num_iter
      * @param use_huber_kernel
      */
-    explicit global_bundle_adjuster(data::map_database* map_db, const unsigned int num_iter = 10, const bool use_huber_kernel = true);
+    explicit global_bundle_adjuster(const unsigned int num_iter = 10, const bool use_huber_kernel = true);
 
     /**
      * Destructor
      */
     virtual ~global_bundle_adjuster() = default;
 
-    void optimize_for_initialization(bool* const force_stop_flag = nullptr) const;
+    void optimize_for_initialization(const std::vector<std::shared_ptr<data::keyframe>>& keyfrms,
+                                     const std::vector<std::shared_ptr<data::landmark>>& lms,
+                                     const std::vector<std::shared_ptr<data::marker>>& markers,
+                                     bool* const force_stop_flag = nullptr) const;
 
     /**
      * Perform optimization
+     * @param keyfrms
      * @param optimized_keyfrm_ids
      * @param optimized_landmark_ids
      * @param lm_to_pos_w_after_global_BA
@@ -35,16 +38,14 @@ public:
      * @param force_stop_flag
      * @return false if aborted
      */
-    bool optimize(std::unordered_set<unsigned int>& optimized_keyfrm_ids,
+    bool optimize(const std::vector<std::shared_ptr<data::keyframe>>& keyfrms,
+                  std::unordered_set<unsigned int>& optimized_keyfrm_ids,
                   std::unordered_set<unsigned int>& optimized_landmark_ids,
                   eigen_alloc_unord_map<unsigned int, Vec3_t>& lm_to_pos_w_after_global_BA,
                   eigen_alloc_unord_map<unsigned int, Mat44_t>& keyfrm_to_pose_cw_after_global_BA,
                   bool* const force_stop_flag = nullptr) const;
 
 private:
-    //! map database
-    const data::map_database* map_db_;
-
     //! number of iterations of optimization
     unsigned int num_iter_;
 

--- a/src/stella_vslam/optimize/graph_optimizer.cc
+++ b/src/stella_vslam/optimize/graph_optimizer.cc
@@ -41,8 +41,25 @@ void graph_optimizer::optimize(const std::shared_ptr<data::keyframe>& loop_keyfr
 
     // 2. Add vertices
 
-    const auto all_keyfrms = map_db_->get_all_keyframes();
-    const auto all_lms = map_db_->get_all_landmarks();
+    const auto all_keyfrms = curr_keyfrm->graph_node_->get_keyframes_from_root();
+    std::unordered_set<unsigned int> already_found_landmark_ids;
+    std::vector<std::shared_ptr<data::landmark>> all_lms;
+    for (const auto& keyfrm : all_keyfrms) {
+        for (const auto& lm : keyfrm->get_landmarks()) {
+            if (!lm) {
+                continue;
+            }
+            if (lm->will_be_erased()) {
+                continue;
+            }
+            if (already_found_landmark_ids.count(lm->id_)) {
+                continue;
+            }
+
+            already_found_landmark_ids.insert(lm->id_);
+            all_lms.push_back(lm);
+        }
+    }
 
     // Transform the pre-modified poses of all the keyframes to Sim3, and save them
     eigen_alloc_unord_map<unsigned int, g2o::Sim3> Sim3s_cw;

--- a/src/stella_vslam/optimize/graph_optimizer.cc
+++ b/src/stella_vslam/optimize/graph_optimizer.cc
@@ -76,8 +76,8 @@ void graph_optimizer::optimize(const std::shared_ptr<data::keyframe>& loop_keyfr
             keyfrm_vtx->setEstimate(Sim3_cw);
         }
 
-        // Fix the loop keyframe or origin keyframe
-        if (*keyfrm == *loop_keyfrm || keyfrm->id_ == 0) {
+        // Fix the loop keyframe or root keyframe
+        if (*keyfrm == *loop_keyfrm || keyfrm->graph_node_->is_spanning_root()) {
             keyfrm_vtx->setFixed(true);
         }
 

--- a/src/stella_vslam/optimize/graph_optimizer.cc
+++ b/src/stella_vslam/optimize/graph_optimizer.cc
@@ -19,8 +19,8 @@
 namespace stella_vslam {
 namespace optimize {
 
-graph_optimizer::graph_optimizer(data::map_database* map_db, const bool fix_scale)
-    : map_db_(map_db), fix_scale_(fix_scale) {}
+graph_optimizer::graph_optimizer(const bool fix_scale)
+    : fix_scale_(fix_scale) {}
 
 void graph_optimizer::optimize(const std::shared_ptr<data::keyframe>& loop_keyfrm, const std::shared_ptr<data::keyframe>& curr_keyfrm,
                                const module::keyframe_Sim3_pairs_t& non_corrected_Sim3s,

--- a/src/stella_vslam/optimize/graph_optimizer.h
+++ b/src/stella_vslam/optimize/graph_optimizer.h
@@ -20,10 +20,9 @@ class graph_optimizer {
 public:
     /**
      * Constructor
-     * @param map_db
      * @param fix_scale
      */
-    explicit graph_optimizer(data::map_database* map_db, const bool fix_scale);
+    explicit graph_optimizer(const bool fix_scale);
 
     /**
      * Destructor
@@ -45,9 +44,6 @@ public:
                   std::unordered_map<unsigned int, unsigned int>& found_lm_to_ref_keyfrm_id) const;
 
 private:
-    //! map database
-    const data::map_database* map_db_;
-
     //! SE3 optimization or Sim3 optimization
     const bool fix_scale_;
 };

--- a/src/stella_vslam/optimize/local_bundle_adjuster.cc
+++ b/src/stella_vslam/optimize/local_bundle_adjuster.cc
@@ -50,7 +50,7 @@ void local_bundle_adjuster::optimize(data::map_database* map_db,
         if (local_keyfrm->will_be_erased()) {
             continue;
         }
-        if (local_keyfrm->id_ == 0) {
+        if (local_keyfrm->graph_node_->is_spanning_root()) {
             continue;
         }
 

--- a/src/stella_vslam/tracking_module.cc
+++ b/src/stella_vslam/tracking_module.cc
@@ -261,8 +261,7 @@ bool tracking_module::initialize() {
 
     // pass all of the keyframes to the mapping module
     assert(!is_stopped_keyframe_insertion_);
-    const auto keyfrms = map_db_->get_all_keyframes();
-    for (const auto& keyfrm : keyfrms) {
+    for (const auto& keyfrm : curr_frm_.ref_keyfrm_->graph_node_->get_keyframes_from_root()) {
         mapper_->queue_keyframe(keyfrm);
     }
 


### PR DESCRIPTION
Reduced processing by origin_keyfrm_ and get_all_keyframes. This makes it easier to handle multiple non-overlapping maps. I will add the feature to load additional maps in a later pull request.