### PR TITLE
Load non-overlapping maps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,37 +119,37 @@ jobs:
       - name: SLAM test (monocular) with EuRoC MAV dataset (MH_01)
         run: |
           cd build
-          ./run_euroc_slam -v /datasets/orb_vocab/orb_vocab.fbow -d /datasets/EuRoC/MH_01 -c ../example/euroc/EuRoC_mono.yaml --frame-skip 2 --no-sleep --log-level=debug --eval-log-dir . --map-db MH_01_mono.msg
+          ./run_euroc_slam -v /datasets/orb_vocab/orb_vocab.fbow -d /datasets/EuRoC/MH_01 -c ../example/euroc/EuRoC_mono.yaml --frame-skip 2 --no-sleep --log-level=debug --eval-log-dir . --map-db-out MH_01_mono.msg
           mv frame_trajectory.txt ../artifact/frame_trajectory_MH_01_mono_slam.txt
           mv track_times.txt ../artifact/track_times_MH_01_mono_slam.txt
       - name: SLAM test (stereo) with EuRoC MAV dataset (MH_01)
         run: |
           cd build
-          ./run_euroc_slam -v /datasets/orb_vocab/orb_vocab.fbow -d /datasets/EuRoC/MH_01 -c ../example/euroc/EuRoC_stereo.yaml --frame-skip 2 --no-sleep --log-level=debug --eval-log-dir . --map-db MH_01_stereo.msg
+          ./run_euroc_slam -v /datasets/orb_vocab/orb_vocab.fbow -d /datasets/EuRoC/MH_01 -c ../example/euroc/EuRoC_stereo.yaml --frame-skip 2 --no-sleep --log-level=debug --eval-log-dir . --map-db-out MH_01_stereo.msg
           mv frame_trajectory.txt ../artifact/frame_trajectory_MH_01_stereo_slam.txt
           mv track_times.txt ../artifact/track_times_MH_01_stereo_slam.txt
       - name: Localization test (monocular) with EuRoC MAV dataset (MH_01)
         run: |
           cd build
-          ./run_euroc_slam --load-map --disable-mapping -v /datasets/orb_vocab/orb_vocab.fbow -d /datasets/EuRoC/MH_01 -c ../example/euroc/EuRoC_mono.yaml --frame-skip 2 --no-sleep --log-level=debug --eval-log-dir . --map-db MH_01_mono.msg
+          ./run_euroc_slam --disable-mapping -v /datasets/orb_vocab/orb_vocab.fbow -d /datasets/EuRoC/MH_01 -c ../example/euroc/EuRoC_mono.yaml --frame-skip 2 --no-sleep --log-level=debug --eval-log-dir . --map-db-in MH_01_mono.msg
           mv frame_trajectory.txt ../artifact/frame_trajectory_MH_01_mono_localization.txt
           mv track_times.txt ../artifact/track_times_MH_01_mono_localization.txt
       - name: SLAM test (monocular) with EuRoC MAV dataset (MH_04)
         run: |
           cd build
-          ./run_euroc_slam -v /datasets/orb_vocab/orb_vocab.fbow -d /datasets/EuRoC/MH_04 -c ../example/euroc/EuRoC_mono.yaml --frame-skip 2 --no-sleep --log-level=debug --eval-log-dir . --map-db MH_04_mono.msg
+          ./run_euroc_slam -v /datasets/orb_vocab/orb_vocab.fbow -d /datasets/EuRoC/MH_04 -c ../example/euroc/EuRoC_mono.yaml --frame-skip 2 --no-sleep --log-level=debug --eval-log-dir . --map-db-out MH_04_mono.msg
           mv frame_trajectory.txt ../artifact/frame_trajectory_MH_04_mono_slam.txt
           mv track_times.txt ../artifact/track_times_MH_04_mono_slam.txt
       - name: SLAM test (stereo) with EuRoC MAV dataset (MH_04)
         run: |
           cd build
-          ./run_euroc_slam -v /datasets/orb_vocab/orb_vocab.fbow -d /datasets/EuRoC/MH_04 -c ../example/euroc/EuRoC_stereo.yaml --frame-skip 2 --no-sleep --log-level=debug --eval-log-dir . --map-db MH_04_stereo.msg
+          ./run_euroc_slam -v /datasets/orb_vocab/orb_vocab.fbow -d /datasets/EuRoC/MH_04 -c ../example/euroc/EuRoC_stereo.yaml --frame-skip 2 --no-sleep --log-level=debug --eval-log-dir . --map-db-out MH_04_stereo.msg
           mv frame_trajectory.txt ../artifact/frame_trajectory_MH_04_stereo_slam.txt
           mv track_times.txt ../artifact/track_times_MH_04_stereo_slam.txt
       - name: Localization test (monocular) with EuRoC MAV dataset (MH_04)
         run: |
           cd build
-          ./run_euroc_slam --load-map --disable-mapping -v /datasets/orb_vocab/orb_vocab.fbow -d /datasets/EuRoC/MH_04 -c ../example/euroc/EuRoC_mono.yaml --frame-skip 2 --no-sleep --log-level=debug --eval-log-dir . --map-db MH_04_mono.msg
+          ./run_euroc_slam --disable-mapping -v /datasets/orb_vocab/orb_vocab.fbow -d /datasets/EuRoC/MH_04 -c ../example/euroc/EuRoC_mono.yaml --frame-skip 2 --no-sleep --log-level=debug --eval-log-dir . --map-db-in MH_04_mono.msg
           mv frame_trajectory.txt ../artifact/frame_trajectory_MH_04_mono_localization.txt
           mv track_times.txt ../artifact/track_times_MH_04_mono_localization.txt
       - name: download openvslam_test_dataset
@@ -163,19 +163,19 @@ jobs:
       - name: SLAM test with equirectangular dataset (1)
         run: |
           cd build
-          ./run_video_slam -v /datasets/orb_vocab/orb_vocab.fbow -m ../openvslam_test_dataset/1/equirectangular/video.mp4 -c ../equirectangular.yaml --no-sleep --log-level=debug --eval-log-dir . --map-db equirectangular_map.msg -t 0.0
+          ./run_video_slam -v /datasets/orb_vocab/orb_vocab.fbow -m ../openvslam_test_dataset/1/equirectangular/video.mp4 -c ../equirectangular.yaml --no-sleep --log-level=debug --eval-log-dir . --map-db-out equirectangular_map.msg -t 0.0
           mv frame_trajectory.txt ../artifact/frame_trajectory_equirectangular_1.txt
           mv track_times.txt ../artifact/track_times_equirectangular_1.txt
       - name: SLAM test with equirectangular dataset (2)
         run: |
           cd build
-          ./run_video_slam -v /datasets/orb_vocab/orb_vocab.fbow -m ../openvslam_test_dataset/2/equirectangular/video.mp4 -c ../equirectangular.yaml --no-sleep --log-level=debug --eval-log-dir . --map-db equirectangular_map.msg -t 0.0
+          ./run_video_slam -v /datasets/orb_vocab/orb_vocab.fbow -m ../openvslam_test_dataset/2/equirectangular/video.mp4 -c ../equirectangular.yaml --no-sleep --log-level=debug --eval-log-dir . --map-db-out equirectangular_map.msg -t 0.0
           mv frame_trajectory.txt ../artifact/frame_trajectory_equirectangular_2.txt
           mv track_times.txt ../artifact/track_times_equirectangular_2.txt
       - name: SLAM test with equirectangular dataset (3)
         run: |
           cd build
-          ./run_video_slam -v /datasets/orb_vocab/orb_vocab.fbow -m ../openvslam_test_dataset/3/equirectangular/video.mp4 -c ../equirectangular.yaml --no-sleep --log-level=debug --eval-log-dir . --map-db equirectangular_map.msg -t 0.0
+          ./run_video_slam -v /datasets/orb_vocab/orb_vocab.fbow -m ../openvslam_test_dataset/3/equirectangular/video.mp4 -c ../equirectangular.yaml --no-sleep --log-level=debug --eval-log-dir . --map-db-out equirectangular_map.msg -t 0.0
           mv frame_trajectory.txt ../artifact/frame_trajectory_equirectangular_3.txt
           mv track_times.txt ../artifact/track_times_equirectangular_3.txt
       - name: Evaluation
@@ -256,11 +256,11 @@ jobs:
       - name: mapping test with the tutorial
         run: |
           cd build
-          ./run_video_slam -v /datasets/orb_vocab/orb_vocab.fbow -m ./video_for_ci_1/video.mp4 -c ../example/aist/equirectangular.yaml --frame-skip 3 --no-sleep --log-level=debug --eval-log-dir . --map-db map.msg
+          ./run_video_slam -v /datasets/orb_vocab/orb_vocab.fbow -m ./video_for_ci_1/video.mp4 -c ../example/aist/equirectangular.yaml --frame-skip 3 --no-sleep --log-level=debug --eval-log-dir . --map-db-out map.msg
       - name: localization test with the tutorial
         run: |
           cd build
-          ./run_video_slam --load-map --disable-mapping -v /datasets/orb_vocab/orb_vocab.fbow -m ./video_for_ci_1/video.mp4 -c ../example/aist/equirectangular.yaml --frame-skip 3 --no-sleep --log-level=debug --eval-log-dir . --map-db map.msg
+          ./run_video_slam --disable-mapping -v /datasets/orb_vocab/orb_vocab.fbow -m ./video_for_ci_1/video.mp4 -c ../example/aist/equirectangular.yaml --frame-skip 3 --no-sleep --log-level=debug --eval-log-dir . --map-db-in map.msg
 
   rosdep_foxy:
     runs-on: ubuntu-latest

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "3rd/tinycolormap"]
 	path = 3rd/tinycolormap
 	url = https://github.com/yuki-koyama/tinycolormap.git
+[submodule "3rd/filesystem"]
+	path = 3rd/filesystem
+	url = https://github.com/gulrak/filesystem

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Feedbacks, feature requests, and contribution are welcome!
 
 The following files are derived from third-party libraries.
 
+- `./3rd/filesystem` : [gulrak/filesystem](https://github.com/gulrak/filesystem) (MIT license)
 - `./3rd/json` : [nlohmann/json \[v3.6.1\]](https://github.com/nlohmann/json) (MIT license)
 - `./3rd/popl` : [badaix/popl \[v1.2.0\]](https://github.com/badaix/popl) (MIT license)
 - `./3rd/spdlog` : [gabime/spdlog \[v1.3.1\]](https://github.com/gabime/spdlog) (MIT license)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,5 +1,8 @@
 # ----- Find dependencies -----
 
+# filesystem
+set(filesystem_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/3rd/filesystem/include)
+
 # popl
 set(popl_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/3rd/popl/include)
 
@@ -96,9 +99,10 @@ foreach(EXECUTABLE_TARGET IN LISTS EXECUTABLE_TARGETS)
                           opencv_imgcodecs
                           opencv_videoio)
 
-    # include popl and spdlog headers
+    # include 3rd party library headers
     target_include_directories(${EXECUTABLE_TARGET}
                                PRIVATE
                                $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rd/popl/include>
+                               $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rd/filesystem/include>
                                $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rd/spdlog/include>)
 endforeach()

--- a/example/run_euroc_slam.cc
+++ b/example/run_euroc_slam.cc
@@ -26,6 +26,9 @@
 #include <spdlog/spdlog.h>
 #include <popl.hpp>
 
+#include <ghc/filesystem.hpp>
+namespace fs = ghc::filesystem;
+
 #ifdef USE_STACK_TRACE_LOGGER
 #include <backward.hpp>
 #endif
@@ -320,8 +323,8 @@ int main(int argc, char* argv[]) {
     auto auto_term = op.add<popl::Switch>("", "auto-term", "automatically terminate the viewer");
     auto log_level = op.add<popl::Value<std::string>>("", "log-level", "log level", "info");
     auto eval_log_dir = op.add<popl::Value<std::string>>("", "eval-log-dir", "store trajectory and tracking times at this path (Specify the directory where it exists.)", "");
-    auto map_db_path = op.add<popl::Value<std::string>>("p", "map-db", "store a map database at this path after slam", "");
-    auto load_map = op.add<popl::Switch>("", "load-map", "load a map database");
+    auto map_db_path_in = op.add<popl::Value<std::string>>("i", "map-db-in", "load a map from this path", "");
+    auto map_db_path_out = op.add<popl::Value<std::string>>("o", "map-db-out", "store a map database at this path after slam", "");
     auto disable_mapping = op.add<popl::Switch>("", "disable-mapping", "disable mapping");
 
     auto equal_hist = op.add<popl::Switch>("", "equal-hist", "apply histogram equalization");
@@ -376,10 +379,19 @@ int main(int argc, char* argv[]) {
     // build a slam system
     stella_vslam::system slam(cfg, vocab_file_path->value());
     bool need_initialize = true;
-    if (load_map->is_set()) {
+    if (map_db_path_in->is_set()) {
         need_initialize = false;
-        // load the prebuilt map
-        slam.load_map_database(map_db_path->value());
+        const auto path = fs::path(map_db_path_in->value());
+        if (path.extension() == ".yaml") {
+            YAML::Node node = YAML::LoadFile(path);
+            for (const auto& map_path : node["maps"].as<std::vector<std::string>>()) {
+                slam.load_map_database(path.parent_path() / map_path);
+            }
+        }
+        else {
+            // load the prebuilt map
+            slam.load_map_database(path);
+        }
     }
     slam.startup(need_initialize);
     if (disable_mapping->is_set()) {
@@ -396,7 +408,7 @@ int main(int argc, char* argv[]) {
                       wait_loop_ba->is_set(),
                       auto_term->is_set(),
                       eval_log_dir->value(),
-                      map_db_path->value(),
+                      map_db_path_out->value(),
                       equal_hist->is_set());
     }
     else if (slam.get_camera()->setup_type_ == stella_vslam::camera::setup_type_t::Stereo) {
@@ -408,7 +420,7 @@ int main(int argc, char* argv[]) {
                         wait_loop_ba->is_set(),
                         auto_term->is_set(),
                         eval_log_dir->value(),
-                        map_db_path->value(),
+                        map_db_path_out->value(),
                         equal_hist->is_set());
     }
     else {

--- a/example/run_image_slam.cc
+++ b/example/run_image_slam.cc
@@ -22,6 +22,9 @@
 #include <spdlog/spdlog.h>
 #include <popl.hpp>
 
+#include <ghc/filesystem.hpp>
+namespace fs = ghc::filesystem;
+
 #ifdef USE_STACK_TRACE_LOGGER
 #include <backward.hpp>
 #endif
@@ -174,8 +177,8 @@ int main(int argc, char* argv[]) {
     auto auto_term = op.add<popl::Switch>("", "auto-term", "automatically terminate the viewer");
     auto log_level = op.add<popl::Value<std::string>>("", "log-level", "log level", "info");
     auto eval_log_dir = op.add<popl::Value<std::string>>("", "eval-log-dir", "store trajectory and tracking times at this path (Specify the directory where it exists.)", "");
-    auto map_db_path = op.add<popl::Value<std::string>>("p", "map-db", "store a map database at this path after slam", "");
-    auto load_map = op.add<popl::Switch>("", "load-map", "load a map database");
+    auto map_db_path_in = op.add<popl::Value<std::string>>("i", "map-db-in", "load a map from this path", "");
+    auto map_db_path_out = op.add<popl::Value<std::string>>("o", "map-db-out", "store a map database at this path after slam", "");
     auto disable_mapping = op.add<popl::Switch>("", "disable-mapping", "disable mapping");
     auto start_timestamp = op.add<popl::Value<double>>("t", "start-timestamp", "timestamp of the start of the video capture");
     try {
@@ -244,10 +247,19 @@ int main(int argc, char* argv[]) {
     // build a slam system
     stella_vslam::system slam(cfg, vocab_file_path->value());
     bool need_initialize = true;
-    if (load_map->is_set()) {
+    if (map_db_path_in->is_set()) {
         need_initialize = false;
-        // load the prebuilt map
-        slam.load_map_database(map_db_path->value());
+        const auto path = fs::path(map_db_path_in->value());
+        if (path.extension() == ".yaml") {
+            YAML::Node node = YAML::LoadFile(path);
+            for (const auto& map_path : node["maps"].as<std::vector<std::string>>()) {
+                slam.load_map_database(path.parent_path() / map_path);
+            }
+        }
+        else {
+            // load the prebuilt map
+            slam.load_map_database(path);
+        }
     }
     slam.startup(need_initialize);
     if (disable_mapping->is_set()) {
@@ -265,7 +277,7 @@ int main(int argc, char* argv[]) {
                       wait_loop_ba->is_set(),
                       auto_term->is_set(),
                       eval_log_dir->value(),
-                      map_db_path->value(),
+                      map_db_path_out->value(),
                       timestamp);
     }
     else {

--- a/example/run_kitti_slam.cc
+++ b/example/run_kitti_slam.cc
@@ -24,6 +24,9 @@
 #include <spdlog/spdlog.h>
 #include <popl.hpp>
 
+#include <ghc/filesystem.hpp>
+namespace fs = ghc::filesystem;
+
 #ifdef USE_STACK_TRACE_LOGGER
 #include <backward.hpp>
 #endif
@@ -290,8 +293,8 @@ int main(int argc, char* argv[]) {
     auto auto_term = op.add<popl::Switch>("", "auto-term", "automatically terminate the viewer");
     auto log_level = op.add<popl::Value<std::string>>("", "log-level", "log level", "info");
     auto eval_log_dir = op.add<popl::Value<std::string>>("", "eval-log-dir", "store trajectory and tracking times at this path (Specify the directory where it exists.)", "");
-    auto map_db_path = op.add<popl::Value<std::string>>("p", "map-db", "store a map database at this path after slam", "");
-    auto load_map = op.add<popl::Switch>("", "load-map", "load a map database");
+    auto map_db_path_in = op.add<popl::Value<std::string>>("i", "map-db-in", "load a map from this path", "");
+    auto map_db_path_out = op.add<popl::Value<std::string>>("o", "map-db-out", "store a map database at this path after slam", "");
     auto disable_mapping = op.add<popl::Switch>("", "disable-mapping", "disable mapping");
     try {
         op.parse(argc, argv);
@@ -343,10 +346,19 @@ int main(int argc, char* argv[]) {
     // build a slam system
     stella_vslam::system slam(cfg, vocab_file_path->value());
     bool need_initialize = true;
-    if (load_map->is_set()) {
+    if (map_db_path_in->is_set()) {
         need_initialize = false;
-        // load the prebuilt map
-        slam.load_map_database(map_db_path->value());
+        const auto path = fs::path(map_db_path_in->value());
+        if (path.extension() == ".yaml") {
+            YAML::Node node = YAML::LoadFile(path);
+            for (const auto& map_path : node["maps"].as<std::vector<std::string>>()) {
+                slam.load_map_database(path.parent_path() / map_path);
+            }
+        }
+        else {
+            // load the prebuilt map
+            slam.load_map_database(path);
+        }
     }
     slam.startup(need_initialize);
     if (disable_mapping->is_set()) {
@@ -363,7 +375,7 @@ int main(int argc, char* argv[]) {
                       wait_loop_ba->is_set(),
                       auto_term->is_set(),
                       eval_log_dir->value(),
-                      map_db_path->value());
+                      map_db_path_out->value());
     }
     else if (slam.get_camera()->setup_type_ == stella_vslam::camera::setup_type_t::Stereo) {
         stereo_tracking(slam,
@@ -374,7 +386,7 @@ int main(int argc, char* argv[]) {
                         wait_loop_ba->is_set(),
                         auto_term->is_set(),
                         eval_log_dir->value(),
-                        map_db_path->value());
+                        map_db_path_out->value());
     }
     else {
         throw std::runtime_error("Invalid setup type: " + slam.get_camera()->get_setup_type_string());

--- a/example/run_tum_rgbd_slam.cc
+++ b/example/run_tum_rgbd_slam.cc
@@ -24,6 +24,9 @@
 #include <spdlog/spdlog.h>
 #include <popl.hpp>
 
+#include <ghc/filesystem.hpp>
+namespace fs = ghc::filesystem;
+
 #ifdef USE_STACK_TRACE_LOGGER
 #include <backward.hpp>
 #endif
@@ -290,8 +293,8 @@ int main(int argc, char* argv[]) {
     auto auto_term = op.add<popl::Switch>("", "auto-term", "automatically terminate the viewer");
     auto log_level = op.add<popl::Value<std::string>>("", "log-level", "log level", "info");
     auto eval_log_dir = op.add<popl::Value<std::string>>("", "eval-log-dir", "store trajectory and tracking times at this path (Specify the directory where it exists.)", "");
-    auto map_db_path = op.add<popl::Value<std::string>>("p", "map-db", "store a map database at this path after slam", "");
-    auto load_map = op.add<popl::Switch>("", "load-map", "load a map database");
+    auto map_db_path_in = op.add<popl::Value<std::string>>("i", "map-db-in", "load a map from this path", "");
+    auto map_db_path_out = op.add<popl::Value<std::string>>("o", "map-db-out", "store a map database at this path after slam", "");
     auto disable_mapping = op.add<popl::Switch>("", "disable-mapping", "disable mapping");
 
     try {
@@ -344,10 +347,19 @@ int main(int argc, char* argv[]) {
     // build a slam system
     stella_vslam::system slam(cfg, vocab_file_path->value());
     bool need_initialize = true;
-    if (load_map->is_set()) {
+    if (map_db_path_in->is_set()) {
         need_initialize = false;
-        // load the prebuilt map
-        slam.load_map_database(map_db_path->value());
+        const auto path = fs::path(map_db_path_in->value());
+        if (path.extension() == ".yaml") {
+            YAML::Node node = YAML::LoadFile(path);
+            for (const auto& map_path : node["maps"].as<std::vector<std::string>>()) {
+                slam.load_map_database(path.parent_path() / map_path);
+            }
+        }
+        else {
+            // load the prebuilt map
+            slam.load_map_database(path);
+        }
     }
     slam.startup(need_initialize);
     if (disable_mapping->is_set()) {
@@ -364,7 +376,7 @@ int main(int argc, char* argv[]) {
                       wait_loop_ba->is_set(),
                       auto_term->is_set(),
                       eval_log_dir->value(),
-                      map_db_path->value());
+                      map_db_path_out->value());
     }
     else if (slam.get_camera()->setup_type_ == stella_vslam::camera::setup_type_t::RGBD) {
         rgbd_tracking(slam,
@@ -375,7 +387,7 @@ int main(int argc, char* argv[]) {
                       wait_loop_ba->is_set(),
                       auto_term->is_set(),
                       eval_log_dir->value(),
-                      map_db_path->value());
+                      map_db_path_out->value());
     }
     else {
         throw std::runtime_error("Invalid setup type: " + slam.get_camera()->get_setup_type_string());

--- a/example/run_video_slam.cc
+++ b/example/run_video_slam.cc
@@ -21,6 +21,9 @@
 #include <spdlog/spdlog.h>
 #include <popl.hpp>
 
+#include <ghc/filesystem.hpp>
+namespace fs = ghc::filesystem;
+
 #ifdef USE_STACK_TRACE_LOGGER
 #include <backward.hpp>
 #endif
@@ -184,8 +187,8 @@ int main(int argc, char* argv[]) {
     auto auto_term = op.add<popl::Switch>("", "auto-term", "automatically terminate the viewer");
     auto log_level = op.add<popl::Value<std::string>>("", "log-level", "log level", "info");
     auto eval_log_dir = op.add<popl::Value<std::string>>("", "eval-log-dir", "store trajectory and tracking times at this path (Specify the directory where it exists.)", "");
-    auto map_db_path = op.add<popl::Value<std::string>>("p", "map-db", "store a map database at this path after slam", "");
-    auto load_map = op.add<popl::Switch>("", "load-map", "load a map database");
+    auto map_db_path_in = op.add<popl::Value<std::string>>("i", "map-db-in", "load a map from this path", "");
+    auto map_db_path_out = op.add<popl::Value<std::string>>("o", "map-db-out", "store a map database at this path after slam", "");
     auto disable_mapping = op.add<popl::Switch>("", "disable-mapping", "disable mapping");
     auto start_timestamp = op.add<popl::Value<double>>("t", "start-timestamp", "timestamp of the start of the video capture");
     try {
@@ -254,10 +257,19 @@ int main(int argc, char* argv[]) {
     // build a slam system
     stella_vslam::system slam(cfg, vocab_file_path->value());
     bool need_initialize = true;
-    if (load_map->is_set()) {
+    if (map_db_path_in->is_set()) {
         need_initialize = false;
-        // load the prebuilt map
-        slam.load_map_database(map_db_path->value());
+        const auto path = fs::path(map_db_path_in->value());
+        if (path.extension() == ".yaml") {
+            YAML::Node node = YAML::LoadFile(path);
+            for (const auto& map_path : node["maps"].as<std::vector<std::string>>()) {
+                slam.load_map_database(path.parent_path() / map_path);
+            }
+        }
+        else {
+            // load the prebuilt map
+            slam.load_map_database(path);
+        }
     }
     slam.startup(need_initialize);
     if (disable_mapping->is_set()) {
@@ -276,7 +288,7 @@ int main(int argc, char* argv[]) {
                       wait_loop_ba->is_set(),
                       auto_term->is_set(),
                       eval_log_dir->value(),
-                      map_db_path->value(),
+                      map_db_path_out->value(),
                       timestamp);
     }
     else {

--- a/scripts/ubuntu/README.md
+++ b/scripts/ubuntu/README.md
@@ -56,7 +56,7 @@ If you finish all the above procedure, you will see the terminal inside a docker
 #### run tracking and mapping
 
 ```shell
-./run_video_slam -v /vocab/orb_vocab.fbow -m /dataset/aist_living_lab_1/video.mp4 -c ../example/aist/equirectangular.yaml --frame-skip 3 --no-sleep --map-db map.msg
+./run_video_slam -v /vocab/orb_vocab.fbow -m /dataset/aist_living_lab_1/video.mp4 -c ../example/aist/equirectangular.yaml --frame-skip 3 --no-sleep --map-db-out map.msg
 ```
 
 After you see the window is stopped, press "Terminate" button in the left pane.
@@ -66,7 +66,7 @@ You can use it for the below tracking demo.
 #### run localization
 
 ```shell
-./run_video_slam --load-map --disable-mapping -v /vocab/orb_vocab.fbow -m /dataset/aist_living_lab_2/video.mp4 -c ../example/aist/equirectangular.yaml --frame-skip 3 --no-sleep --map-db map.msg
+./run_video_slam --disable-mapping -v /vocab/orb_vocab.fbow -m /dataset/aist_living_lab_2/video.mp4 -c ../example/aist/equirectangular.yaml --frame-skip 3 --no-sleep --map-db-in map.msg
 ```
 
 ## Run stella_vslam on your own video

--- a/src/stella_vslam/io/map_database_io_msgpack.cc
+++ b/src/stella_vslam/io/map_database_io_msgpack.cc
@@ -81,9 +81,6 @@ void map_database_io_msgpack::load(const std::string& path,
 
     const auto json = nlohmann::json::from_msgpack(msgpack);
 
-    // load next ID
-    map_db->next_keyframe_id_ = json.at("keyframe_next_id").get<unsigned int>();
-    map_db->next_landmark_id_ = json.at("landmark_next_id").get<unsigned int>();
     // load database
     const auto json_cameras = json.at("cameras");
     cam_db->from_json(json_cameras);
@@ -92,6 +89,11 @@ void map_database_io_msgpack::load(const std::string& path,
     const auto json_keyfrms = json.at("keyframes");
     const auto json_landmarks = json.at("landmarks");
     map_db->from_json(cam_db, orb_params_db, bow_vocab, json_keyfrms, json_landmarks);
+    // load next ID
+    map_db->next_keyframe_id_ += json.at("keyframe_next_id").get<unsigned int>();
+    map_db->next_landmark_id_ += json.at("landmark_next_id").get<unsigned int>();
+
+    // update bow database
     const auto keyfrms = map_db->get_all_keyframes();
     for (const auto& keyfrm : keyfrms) {
         bow_db->add_keyframe(keyfrm);

--- a/src/stella_vslam/io/map_database_io_sqlite3.cc
+++ b/src/stella_vslam/io/map_database_io_sqlite3.cc
@@ -63,9 +63,11 @@ void map_database_io_sqlite3::load(const std::string& path,
     }
 
     // load from database
-    bool ok = load_stats(db, map_db);
-    ok = ok && cam_db->from_db(db);
+    bool ok = cam_db->from_db(db);
     ok = ok && map_db->from_db(db, cam_db, orb_params_db, bow_vocab);
+    ok = ok && load_stats(db, map_db);
+
+    // update bow database
     if (ok) {
         const auto keyfrms = map_db->get_all_keyframes();
         for (const auto& keyfrm : keyfrms) {

--- a/src/stella_vslam/system.cc
+++ b/src/stella_vslam/system.cc
@@ -202,14 +202,14 @@ void system::save_keyframe_trajectory(const std::string& path, const std::string
 
 void system::load_map_database(const std::string& path) const {
     pause_other_threads();
-    map_db_->clear();
-    bow_db_->clear();
+    spdlog::debug("load_map_database: {}", path);
     map_database_io_->load(path, cam_db_, orb_params_db_, map_db_, bow_db_, bow_vocab_);
     resume_other_threads();
 }
 
 void system::save_map_database(const std::string& path) const {
     pause_other_threads();
+    spdlog::debug("save_map_database: {}", path);
     map_database_io_->save(path, cam_db_, orb_params_db_, map_db_);
     resume_other_threads();
 }

--- a/src/stella_vslam/system.h
+++ b/src/stella_vslam/system.h
@@ -79,10 +79,10 @@ public:
     //! Save the keyframe trajectory in the specified format
     void save_keyframe_trajectory(const std::string& path, const std::string& format) const;
 
-    //! Load the map database from the MessagePack file
+    //! Load the map database from file
     void load_map_database(const std::string& path) const;
 
-    //! Save the map database to the MessagePack file
+    //! Save the map database to file
     void save_map_database(const std::string& path) const;
 
     //! Get the map publisher


### PR DESCRIPTION
See

- https://github.com/stella-cv/stella_vslam/discussions/188
- https://github.com/stella-cv/stella_vslam/issues/223
- https://github.com/stella-cv/stella_vslam/pull/265

NOTE:
- Only the last map added is rendered.
- I did not add the features to translate, rotate, or scale the map. If needed, it would be preferable to create another executable that only performs the map conversion.