### PR TITLE
fix missing include

### DIFF
--- a/src/stella_vslam/data/bow_vocabulary.cc
+++ b/src/stella_vslam/data/bow_vocabulary.cc
@@ -1,4 +1,5 @@
 #include "stella_vslam/data/bow_vocabulary.h"
+#include "stella_vslam/util/converter.h"
 #include <spdlog/spdlog.h>
 
 namespace stella_vslam {


### PR DESCRIPTION
Simply adding the include missing in case of DBoW2 usage.