### PR TITLE
Cause map creation/initialisation to fail if the frame has no landmarks/triangulated points.

### DIFF
--- a/src/stella_vslam/data/keyframe.cc
+++ b/src/stella_vslam/data/keyframe.cc
@@ -434,6 +434,7 @@ float keyframe::compute_median_depth(const bool abs) const {
         depths.push_back(abs ? std::abs(pos_c_z) : pos_c_z);
     }
 
+    assert(!depths.empty());
     std::sort(depths.begin(), depths.end());
 
     return depths.at((depths.size() - 1) / 2);


### PR DESCRIPTION
This should prevent `keyframe::compute_median_depth()` from being called in situations when the `depths` vector will be empty; added an assertion just in case.