### PR TITLE
(More) determinism fixes

### DIFF
--- a/src/stella_vslam/data/graph_node.cc
+++ b/src/stella_vslam/data/graph_node.cc
@@ -364,9 +364,9 @@ void graph_node::recover_spanning_connections() {
     spanning_parent_.lock()->graph_node_->erase_spanning_child(owner_keyfrm_.lock());
 }
 
-std::set<std::shared_ptr<keyframe>> graph_node::get_spanning_children() const {
+id_ordered_set<std::shared_ptr<keyframe>> graph_node::get_spanning_children() const {
     std::lock_guard<std::mutex> lock(mtx_);
-    std::set<std::shared_ptr<keyframe>> locked_spanning_children;
+    id_ordered_set<std::shared_ptr<keyframe>> locked_spanning_children;
     for (const auto& keyfrm : spanning_children_) {
         locked_spanning_children.insert(keyfrm.lock());
     }

--- a/src/stella_vslam/data/graph_node.h
+++ b/src/stella_vslam/data/graph_node.h
@@ -116,7 +116,7 @@ public:
     /**
      * Get the children of spanning tree
      */
-    std::set<std::shared_ptr<keyframe>> get_spanning_children() const;
+    id_ordered_set<std::shared_ptr<keyframe>> get_spanning_children() const;
 
     /**
      * Whether this node has the specified child or not

--- a/src/stella_vslam/module/relocalizer.cc
+++ b/src/stella_vslam/module/relocalizer.cc
@@ -361,7 +361,7 @@ std::unique_ptr<solve::pnp_solver> relocalizer::setup_pnp_solver(const std::vect
         valid_landmarks.at(i) = valid_assoc_lms.at(i)->get_pos_in_world();
     }
     // Setup PnP solver
-    return std::unique_ptr<solve::pnp_solver>(new solve::pnp_solver(valid_bearings, valid_keypts, valid_landmarks, scale_factors, use_fixed_seed_));
+    return std::unique_ptr<solve::pnp_solver>(new solve::pnp_solver(valid_bearings, valid_keypts, valid_landmarks, scale_factors, 10, use_fixed_seed_));
 }
 
 } // namespace module


### PR DESCRIPTION
* Sort the set returned by `graph_node::get_spanning_children()` by ID rather than pointer, because passing keyframes to `global_bundle_adjuster::optimize()` in different orders can affect results (in `loop_bundle_adjuster::optimize()`, via `graph_node::get_keyframes_from_root()`).

* Correct argument order for `pnp_solver` constructor call in relocalizer.cc (fixes a change made in #294).