### PR TITLE
Fix error when building without aruco (OpenCV < 4.7)

### DIFF
--- a/src/stella_vslam/marker_detector/aruco.cc
+++ b/src/stella_vslam/marker_detector/aruco.cc
@@ -6,6 +6,7 @@
 #include "stella_vslam/solve/pnp_solver.h"
 
 #if CV_MAJOR_VERSION <= 4 && CV_MINOR_VERSION < 7
+#include <opencv2/aruco.hpp>
 using PredefinedDictionaryType = cv::aruco::PREDEFINED_DICTIONARY_NAME;
 using PredefinedDictionaryObjectType = cv::Ptr<cv::aruco::Dictionary>;
 #else

--- a/src/stella_vslam/marker_detector/aruco.h
+++ b/src/stella_vslam/marker_detector/aruco.h
@@ -6,7 +6,12 @@
 #include <unordered_map>
 
 #if CV_MAJOR_VERSION <= 4 && CV_MINOR_VERSION < 7
-#include <opencv2/aruco.hpp>
+namespace cv {
+namespace aruco {
+class DetectorParameters;
+class Dictionary;
+} // namespace aruco
+} // namespace cv
 #else
 #include <opencv2/objdetect/aruco_detector.hpp>
 #endif


### PR DESCRIPTION
Including <opencv2/aruco.hpp> in marker_detector/aruco.h causes a build failure for older OpenCV versions if `USE_ARUCO` is off due to the file not being present. Partial reversion of changes for #460 returns the header to aruco.cc.

Tested with OpenCV v4.5.5 only.