### PR TITLE
Temporal mapping based odometry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,6 +120,9 @@ jobs:
         run: |
           sed -e 's/backend: "g2o"/backend: "gtsam"/g' example/euroc/EuRoC_mono.yaml > EuRoC_mono_gtsam.yaml
           sed -e 's/backend: "g2o"/backend: "gtsam"/g' example/euroc/EuRoC_stereo.yaml > EuRoC_stereo_gtsam.yaml
+      - name: make config for temporal mapping
+        run: |
+          sed -e 's/erase_temporal_keyframes: false/erase_temporal_keyframes: true/g' -e 's/enable_temporal_keyframe_only_tracking: false/enable_temporal_keyframe_only_tracking: true/g' example/euroc/EuRoC_mono.yaml > EuRoC_mono_temporal_mapping.yaml
       - name: make config for sqlite3 map format
         run: |
           sed -e 's/map_format: "msgpack"/map_format: "sqlite3"/g' example/euroc/EuRoC_mono.yaml > EuRoC_mono_sqlite3.yaml
@@ -148,6 +151,9 @@ jobs:
           ./run_euroc_slam --disable-mapping -v /datasets/orb_vocab/orb_vocab.fbow -d /datasets/EuRoC/MH_01 -c ../example/euroc/EuRoC_mono.yaml --frame-skip 2 --no-sleep --log-level=debug --eval-log-dir . --map-db-in MH_01_mono.msg
           mv frame_trajectory.txt ../artifact/frame_trajectory_MH_01_mono_localization.txt
           mv track_times.txt ../artifact/track_times_MH_01_mono_localization.txt
+          ./run_euroc_slam --temporal-mapping -v /datasets/orb_vocab/orb_vocab.fbow -d /datasets/EuRoC/MH_01 -c ../EuRoC_mono_temporal_mapping.yaml --frame-skip 2 --no-sleep --log-level=debug --eval-log-dir . --map-db-in MH_01_mono.msg
+          mv frame_trajectory.txt ../artifact/frame_trajectory_MH_01_mono_localization_temporal_mapping.txt
+          mv track_times.txt ../artifact/track_times_MH_01_mono_localization_temporal_mapping.txt
           ./run_euroc_slam --disable-mapping -v /datasets/orb_vocab/orb_vocab.fbow -d /datasets/EuRoC/MH_01 -c ../EuRoC_mono_sqlite3.yaml --frame-skip 2 --no-sleep --log-level=debug --map-db-in MH_01_mono_sqlite3.db
       - name: SLAM test (monocular) with EuRoC MAV dataset (MH_04)
         run: |
@@ -167,6 +173,9 @@ jobs:
           ./run_euroc_slam --disable-mapping -v /datasets/orb_vocab/orb_vocab.fbow -d /datasets/EuRoC/MH_04 -c ../example/euroc/EuRoC_mono.yaml --frame-skip 2 --no-sleep --log-level=debug --eval-log-dir . --map-db-in MH_04_mono.msg
           mv frame_trajectory.txt ../artifact/frame_trajectory_MH_04_mono_localization.txt
           mv track_times.txt ../artifact/track_times_MH_04_mono_localization.txt
+          ./run_euroc_slam --temporal-mapping -v /datasets/orb_vocab/orb_vocab.fbow -d /datasets/EuRoC/MH_04 -c ../EuRoC_mono_temporal_mapping.yaml --frame-skip 2 --no-sleep --log-level=debug --eval-log-dir . --map-db-in MH_04_mono.msg
+          mv frame_trajectory.txt ../artifact/frame_trajectory_MH_04_mono_localization_temporal_mapping.txt
+          mv track_times.txt ../artifact/track_times_MH_04_mono_localization_temporal_mapping.txt
       - name: download openvslam_test_dataset
         run: |
           curl -sL "https://github.com/stella-cv/openvslam_test_dataset/raw/main/openvslam_test_dataset.zip" -o openvslam_test_dataset.zip
@@ -228,6 +237,10 @@ jobs:
             bash track_time_print_row.bash artifact/track_times_MH_01_mono_localization.txt
             bash evo_rpe_print_row.bash tum MH_01.tum artifact/frame_trajectory_MH_01_mono_localization.txt -as
             echo '|'
+            echo -n '| EuRoC MH_01 (Localization, perspective, mono, temporal mapping)'
+            bash track_time_print_row.bash artifact/track_times_MH_01_mono_localization_temporal_mapping.txt
+            bash evo_rpe_print_row.bash tum MH_01.tum artifact/frame_trajectory_MH_01_mono_localization_temporal_mapping.txt -as
+            echo '|'
             echo -n '| EuRoC MH_04 (SLAM, perspective, mono)'
             bash track_time_print_row.bash artifact/track_times_MH_04_mono_slam.txt
             bash evo_rpe_print_row.bash tum MH_04.tum artifact/frame_trajectory_MH_04_mono_slam.txt -as
@@ -239,6 +252,10 @@ jobs:
             echo -n '| EuRoC MH_04 (Localization, perspective, mono)'
             bash track_time_print_row.bash artifact/track_times_MH_04_mono_localization.txt
             bash evo_rpe_print_row.bash tum MH_04.tum artifact/frame_trajectory_MH_04_mono_localization.txt -as
+            echo '|'
+            echo -n '| EuRoC MH_04 (Localization, perspective, mono, temporal mapping)'
+            bash track_time_print_row.bash artifact/track_times_MH_04_mono_localization_temporal_mapping.txt
+            bash evo_rpe_print_row.bash tum MH_04.tum artifact/frame_trajectory_MH_04_mono_localization_temporal_mapping.txt -as
             echo '|'
             echo -n '| openvslam_test_dataset 1 (SLAM, equirectangular, mono)'
             bash track_time_print_row.bash artifact/track_times_equirectangular_1.txt

--- a/example/euroc/EuRoC_mono.yaml
+++ b/example/euroc/EuRoC_mono.yaml
@@ -38,9 +38,12 @@ Mapping:
   redundant_obs_ratio_thr: 0.9
   num_covisibilities_for_landmark_generation: 20
   num_covisibilities_for_landmark_fusion: 20
+  erase_temporal_keyframes: false
+  num_temporal_keyframes: 15
 
 Tracking:
   backend: "g2o"
+  enable_temporal_keyframe_only_tracking: false
 
 LoopDetector:
   backend: "g2o"

--- a/example/euroc/EuRoC_stereo.yaml
+++ b/example/euroc/EuRoC_stereo.yaml
@@ -6,16 +6,16 @@ Camera:
   setup: "stereo"
   model: "perspective"
 
-# new "rectified" matrices is the first three cols of the projection matrix which is calculated with cv::stereoRectify()
-# e.g. fx = P1[0][0] or P2[0][0], cx = P1[0][2] or P2[0][2]
-#      fy = P1[1][1] or P2[1][1], cy = P1[1][2] or P2[1][2]
+  # new "rectified" matrices is the first three cols of the projection matrix which is calculated with cv::stereoRectify()
+  # e.g. fx = P1[0][0] or P2[0][0], cx = P1[0][2] or P2[0][2]
+  #      fy = P1[1][1] or P2[1][1], cy = P1[1][2] or P2[1][2]
 
   fx: 435.2046959714599
   fy: 435.2046959714599
   cx: 367.4517211914062
   cy: 252.2008514404297
 
-# there is no distortion after stereo rectification
+  # there is no distortion after stereo rectification
 
   k1: 0.0
   k2: 0.0
@@ -23,7 +23,7 @@ Camera:
   p2: 0.0
   k3: 0.0
 
-# focal_x_baseline is -P2[0][3] which is calculated with cv::stereoRectify()
+  # focal_x_baseline is -P2[0][3] which is calculated with cv::stereoRectify()
 
   fps: 20.0
   cols: 752
@@ -39,10 +39,32 @@ Camera:
 StereoRectifier:
   K_left: [458.654, 0.0, 367.215, 0.0, 457.296, 248.375, 0.0, 0.0, 1.0]
   D_left: [-0.28340811, 0.07395907, 0.00019359, 1.76187114e-05, 0.0]
-  R_left: [0.999966347530033, -0.001422739138722922, 0.008079580483432283, 0.001365741834644127, 0.9999741760894847, 0.007055629199258132, -0.008089410156878961, -0.007044357138835809, 0.9999424675829176]
+  R_left:
+    [
+      0.999966347530033,
+      -0.001422739138722922,
+      0.008079580483432283,
+      0.001365741834644127,
+      0.9999741760894847,
+      0.007055629199258132,
+      -0.008089410156878961,
+      -0.007044357138835809,
+      0.9999424675829176,
+    ]
   K_right: [457.587, 0.0, 379.999, 0.0, 456.134, 255.238, 0.0, 0.0, 1]
   D_right: [-0.28368365, 0.07451284, -0.00010473, -3.555907e-05, 0.0]
-  R_right: [0.9999633526194376, -0.003625811871560086, 0.007755443660172947, 0.003680398547259526, 0.9999684752771629, -0.007035845251224894, -0.007729688520722713, 0.007064130529506649, 0.999945173484644]
+  R_right:
+    [
+      0.9999633526194376,
+      -0.003625811871560086,
+      0.007755443660172947,
+      0.003680398547259526,
+      0.9999684752771629,
+      -0.007035845251224894,
+      -0.007729688520722713,
+      0.007064130529506649,
+      0.999945173484644,
+    ]
 
 Preprocessing:
   min_size: 800
@@ -58,9 +80,12 @@ Mapping:
   backend: "g2o"
   baseline_dist_thr: 0.11007784219
   redundant_obs_ratio_thr: 0.9
+  erase_temporal_keyframes: false
+  num_temporal_keyframes: 15
 
 Tracking:
   backend: "g2o"
+  enable_temporal_keyframe_only_tracking: false
 
 LoopDetector:
   backend: "g2o"

--- a/example/run_camera_slam.cc
+++ b/example/run_camera_slam.cc
@@ -253,6 +253,7 @@ int main(int argc, char* argv[]) {
     auto map_db_path_out = op.add<popl::Value<std::string>>("o", "map-db-out", "store a map database at this path after slam", "");
     auto log_level = op.add<popl::Value<std::string>>("", "log-level", "log level", "info");
     auto disable_mapping = op.add<popl::Switch>("", "disable-mapping", "disable mapping");
+    auto temporal_mapping = op.add<popl::Switch>("", "temporal-mapping", "enable temporal mapping");
     auto disable_gui = op.add<popl::Switch>("", "disable-gui", "run without GUI");
     try {
         op.parse(argc, argv);
@@ -325,6 +326,10 @@ int main(int argc, char* argv[]) {
     slam->startup(need_initialize);
     if (disable_mapping->is_set()) {
         slam->disable_mapping_module();
+    }
+    else if (temporal_mapping->is_set()) {
+        slam->enable_temporal_mapping();
+        slam->disable_loop_detector();
     }
 
     // run tracking

--- a/example/run_euroc_slam.cc
+++ b/example/run_euroc_slam.cc
@@ -342,6 +342,7 @@ int main(int argc, char* argv[]) {
     auto map_db_path_in = op.add<popl::Value<std::string>>("i", "map-db-in", "load a map from this path", "");
     auto map_db_path_out = op.add<popl::Value<std::string>>("o", "map-db-out", "store a map database at this path after slam", "");
     auto disable_mapping = op.add<popl::Switch>("", "disable-mapping", "disable mapping");
+    auto temporal_mapping = op.add<popl::Switch>("", "temporal-mapping", "enable temporal mapping");
     auto equal_hist = op.add<popl::Switch>("", "equal-hist", "apply histogram equalization");
     auto disable_gui = op.add<popl::Switch>("", "disable-gui", "run without GUI");
 
@@ -415,6 +416,10 @@ int main(int argc, char* argv[]) {
     slam->startup(need_initialize);
     if (disable_mapping->is_set()) {
         slam->disable_mapping_module();
+    }
+    else if (temporal_mapping->is_set()) {
+        slam->enable_temporal_mapping();
+        slam->disable_loop_detector();
     }
 
     // run tracking

--- a/example/run_image_slam.cc
+++ b/example/run_image_slam.cc
@@ -188,6 +188,7 @@ int main(int argc, char* argv[]) {
     auto map_db_path_in = op.add<popl::Value<std::string>>("i", "map-db-in", "load a map from this path", "");
     auto map_db_path_out = op.add<popl::Value<std::string>>("o", "map-db-out", "store a map database at this path after slam", "");
     auto disable_mapping = op.add<popl::Switch>("", "disable-mapping", "disable mapping");
+    auto temporal_mapping = op.add<popl::Switch>("", "temporal-mapping", "enable temporal mapping");
     auto start_timestamp = op.add<popl::Value<double>>("t", "start-timestamp", "timestamp of the start of the video capture");
     auto disable_gui = op.add<popl::Switch>("", "disable-gui", "run without GUI");
     try {
@@ -276,6 +277,10 @@ int main(int argc, char* argv[]) {
     slam->startup(need_initialize);
     if (disable_mapping->is_set()) {
         slam->disable_mapping_module();
+    }
+    else if (temporal_mapping->is_set()) {
+        slam->enable_temporal_mapping();
+        slam->disable_loop_detector();
     }
 
     // run tracking

--- a/example/run_kitti_slam.cc
+++ b/example/run_kitti_slam.cc
@@ -312,6 +312,7 @@ int main(int argc, char* argv[]) {
     auto map_db_path_in = op.add<popl::Value<std::string>>("i", "map-db-in", "load a map from this path", "");
     auto map_db_path_out = op.add<popl::Value<std::string>>("o", "map-db-out", "store a map database at this path after slam", "");
     auto disable_mapping = op.add<popl::Switch>("", "disable-mapping", "disable mapping");
+    auto temporal_mapping = op.add<popl::Switch>("", "temporal-mapping", "enable temporal mapping");
     auto disable_gui = op.add<popl::Switch>("", "disable-gui", "run without GUI");
     try {
         op.parse(argc, argv);
@@ -383,6 +384,10 @@ int main(int argc, char* argv[]) {
     slam->startup(need_initialize);
     if (disable_mapping->is_set()) {
         slam->disable_mapping_module();
+    }
+    else if (temporal_mapping->is_set()) {
+        slam->enable_temporal_mapping();
+        slam->disable_loop_detector();
     }
 
     // run tracking

--- a/example/run_tum_rgbd_slam.cc
+++ b/example/run_tum_rgbd_slam.cc
@@ -312,6 +312,7 @@ int main(int argc, char* argv[]) {
     auto map_db_path_in = op.add<popl::Value<std::string>>("i", "map-db-in", "load a map from this path", "");
     auto map_db_path_out = op.add<popl::Value<std::string>>("o", "map-db-out", "store a map database at this path after slam", "");
     auto disable_mapping = op.add<popl::Switch>("", "disable-mapping", "disable mapping");
+    auto temporal_mapping = op.add<popl::Switch>("", "temporal-mapping", "enable temporal mapping");
     auto disable_gui = op.add<popl::Switch>("", "disable-gui", "run without GUI");
 
     try {
@@ -384,6 +385,10 @@ int main(int argc, char* argv[]) {
     slam->startup(need_initialize);
     if (disable_mapping->is_set()) {
         slam->disable_mapping_module();
+    }
+    else if (temporal_mapping->is_set()) {
+        slam->enable_temporal_mapping();
+        slam->disable_loop_detector();
     }
 
     // run tracking

--- a/example/run_video_slam.cc
+++ b/example/run_video_slam.cc
@@ -198,6 +198,7 @@ int main(int argc, char* argv[]) {
     auto map_db_path_in = op.add<popl::Value<std::string>>("i", "map-db-in", "load a map from this path", "");
     auto map_db_path_out = op.add<popl::Value<std::string>>("o", "map-db-out", "store a map database at this path after slam", "");
     auto disable_mapping = op.add<popl::Switch>("", "disable-mapping", "disable mapping");
+    auto temporal_mapping = op.add<popl::Switch>("", "temporal-mapping", "enable temporal mapping");
     auto start_timestamp = op.add<popl::Value<double>>("t", "start-timestamp", "timestamp of the start of the video capture");
     auto disable_gui = op.add<popl::Switch>("", "disable-gui", "run without GUI");
     try {
@@ -286,6 +287,10 @@ int main(int argc, char* argv[]) {
     slam->startup(need_initialize);
     if (disable_mapping->is_set()) {
         slam->disable_mapping_module();
+    }
+    else if (temporal_mapping->is_set()) {
+        slam->enable_temporal_mapping();
+        slam->disable_loop_detector();
     }
 
     // run tracking

--- a/src/stella_vslam/data/map_database.cc
+++ b/src/stella_vslam/data/map_database.cc
@@ -21,13 +21,23 @@ namespace data {
 std::mutex map_database::mtx_database_;
 
 map_database::map_database(unsigned int min_num_shared_lms)
-    : min_num_shared_lms_(min_num_shared_lms) {
+    : fixed_keyframe_id_threshold_(0), min_num_shared_lms_(min_num_shared_lms) {
     spdlog::debug("CONSTRUCT: data::map_database");
 }
 
 map_database::~map_database() {
     clear();
     spdlog::debug("DESTRUCT: data::map_database");
+}
+
+void map_database::set_fixed_keyframe_id_threshold() {
+    std::lock_guard<std::mutex> lock(mtx_map_access_);
+    fixed_keyframe_id_threshold_ = next_keyframe_id_;
+}
+
+unsigned int map_database::get_fixed_keyframe_id_threshold() {
+    std::lock_guard<std::mutex> lock(mtx_map_access_);
+    return fixed_keyframe_id_threshold_;
 }
 
 void map_database::add_keyframe(const std::shared_ptr<keyframe>& keyfrm) {
@@ -237,6 +247,7 @@ void map_database::clear() {
 
     next_keyframe_id_ = 0;
     next_landmark_id_ = 0;
+    fixed_keyframe_id_threshold_ = 0;
 
     spdlog::info("clear map database");
 }

--- a/src/stella_vslam/data/map_database.h
+++ b/src/stella_vslam/data/map_database.h
@@ -42,6 +42,16 @@ public:
     ~map_database();
 
     /**
+     * Set fixed_keyframe_id_threshold
+     */
+    void set_fixed_keyframe_id_threshold();
+
+    /**
+     * Get fixed_keyframe_id_threshold
+     */
+    unsigned int get_fixed_keyframe_id_threshold();
+
+    /**
      * Add keyframe to the database
      * @param keyfrm
      */
@@ -344,6 +354,9 @@ private:
 
     //! local landmarks
     std::vector<std::shared_ptr<landmark>> local_landmarks_;
+
+    //! keyframes with id less than or equal to fixed_keyframe_id_threshold are not optimized
+    unsigned int fixed_keyframe_id_threshold_ = 0;
 
     //-----------------------------------------
     // parameters for global/local mapping (optimization)

--- a/src/stella_vslam/mapping_module.h
+++ b/src/stella_vslam/mapping_module.h
@@ -280,6 +280,12 @@ private:
 
     //! Number of keyframes used for landmark fusion
     const unsigned int num_covisibilities_for_landmark_fusion_ = 10;
+
+    //! If true, remove keyframes past num_temporal_keyframes_
+    const bool erase_temporal_keyframes_ = false;
+
+    //! Number of temporal keyframes
+    const unsigned int num_temporal_keyframes_ = 15;
 };
 
 } // namespace stella_vslam

--- a/src/stella_vslam/module/local_map_updater.h
+++ b/src/stella_vslam/module/local_map_updater.h
@@ -18,7 +18,7 @@ public:
     using keyframe_to_num_shared_lms_t = nondeterministic::unordered_map<std::shared_ptr<data::keyframe>, unsigned int>;
 
     //! Constructor
-    explicit local_map_updater(const data::frame& curr_frm, const unsigned int max_num_local_keyfrms);
+    explicit local_map_updater(const unsigned int max_num_local_keyfrms);
 
     //! Destructor
     ~local_map_updater() = default;
@@ -33,14 +33,20 @@ public:
     std::shared_ptr<data::keyframe> get_nearest_covisibility() const;
 
     //! Acquire the new local map
-    bool acquire_local_map();
+    bool acquire_local_map(const std::vector<std::shared_ptr<data::landmark>>& frm_lms,
+                           const unsigned int num_keypts,
+                           unsigned int keyframe_id_threshold = 0);
 
 private:
     //! Find the local keyframes
-    bool find_local_keyframes();
+    bool find_local_keyframes(const std::vector<std::shared_ptr<data::landmark>>& frm_lms,
+                              const unsigned int num_keypts,
+                              unsigned int keyframe_id_threshold);
 
     //! Count the number of shared landmarks between the current frame and each of the neighbor keyframes
-    keyframe_to_num_shared_lms_t count_num_shared_lms() const;
+    keyframe_to_num_shared_lms_t count_num_shared_lms(const std::vector<std::shared_ptr<data::landmark>>& frm_lms,
+                                                      const unsigned int num_keypts,
+                                                      unsigned int keyframe_id_threshold) const;
 
     //! Find the first-order local keyframes
     auto find_first_local_keyframes(const keyframe_to_num_shared_lms_t& keyfrm_weights,
@@ -53,12 +59,9 @@ private:
         -> std::vector<std::shared_ptr<data::keyframe>>;
 
     //! Find the local landmarks
-    bool find_local_landmarks();
+    bool find_local_landmarks(const std::vector<std::shared_ptr<data::landmark>>& frm_lms,
+                              const unsigned int num_keypts);
 
-    // landmark associations
-    const std::vector<std::shared_ptr<data::landmark>> frm_lms_;
-    // the number of keypoints
-    const unsigned int num_keypts_;
     // maximum number of the local keyframes
     const unsigned int max_num_local_keyfrms_;
 

--- a/src/stella_vslam/module/relocalizer.cc
+++ b/src/stella_vslam/module/relocalizer.cc
@@ -65,7 +65,7 @@ bool relocalizer::reloc_by_candidates(data::frame& curr_frm,
 
         bool ok = reloc_by_candidate(curr_frm, candidate_keyfrm, use_robust_matcher);
         if (ok) {
-            spdlog::info("relocalization succeeded (id={})", candidate_keyfrm->id_);
+            spdlog::info("relocalization succeeded (frame={}, keyframe={})", curr_frm.id_, candidate_keyfrm->id_);
             // TODO: should set the reference keyframe of the current frame
             return true;
         }
@@ -242,8 +242,8 @@ bool relocalizer::refine_pose_by_local_map(data::frame& curr_frm,
                                            const std::shared_ptr<stella_vslam::data::keyframe>& candidate_keyfrm) const {
     // Create local map
     constexpr unsigned int max_num_local_keyfrms = 10;
-    auto local_map_updater = module::local_map_updater(curr_frm, max_num_local_keyfrms);
-    if (!local_map_updater.acquire_local_map()) {
+    auto local_map_updater = module::local_map_updater(max_num_local_keyfrms);
+    if (!local_map_updater.acquire_local_map(curr_frm.get_landmarks(), curr_frm.frm_obs_.num_keypts_)) {
         return false;
     }
     auto local_keyfrms = local_map_updater.get_local_keyframes();

--- a/src/stella_vslam/optimize/local_bundle_adjuster_g2o.cc
+++ b/src/stella_vslam/optimize/local_bundle_adjuster_g2o.cc
@@ -53,6 +53,9 @@ void local_bundle_adjuster_g2o::optimize(data::map_database* map_db,
         if (local_keyfrm->graph_node_->is_spanning_root()) {
             continue;
         }
+        if (local_keyfrm->id_ < map_db->get_fixed_keyframe_id_threshold()) {
+            continue;
+        }
 
         local_keyfrms[local_keyfrm->id_] = local_keyfrm;
         if (local_keyfrm->camera_->setup_type_ != camera::setup_type_t::Monocular) {

--- a/src/stella_vslam/optimize/local_bundle_adjuster_gtsam.cc
+++ b/src/stella_vslam/optimize/local_bundle_adjuster_gtsam.cc
@@ -50,6 +50,9 @@ void local_bundle_adjuster_gtsam::optimize(data::map_database* map_db,
         if (local_keyfrm->graph_node_->is_spanning_root()) {
             continue;
         }
+        if (local_keyfrm->id_ < map_db->get_fixed_keyframe_id_threshold()) {
+            continue;
+        }
 
         local_keyfrms[local_keyfrm->id_] = local_keyfrm;
         if (local_keyfrm->camera_->setup_type_ != camera::setup_type_t::Monocular) {

--- a/src/stella_vslam/system.cc
+++ b/src/stella_vslam/system.cc
@@ -274,6 +274,10 @@ void system::abort_loop_BA() {
     global_optimizer_->abort_loop_BA();
 }
 
+void system::enable_temporal_mapping() {
+    map_db_->set_fixed_keyframe_id_threshold();
+}
+
 data::frame system::create_monocular_frame(const cv::Mat& img, const double timestamp, const cv::Mat& mask) {
     // color conversion
     if (!camera_->is_valid_shape(img)) {

--- a/src/stella_vslam/system.h
+++ b/src/stella_vslam/system.h
@@ -121,6 +121,9 @@ public:
     //! Abort the loop BA externally
     void abort_loop_BA();
 
+    //! Enable temporal mapping
+    void enable_temporal_mapping();
+
     //-----------------------------------------
     // data feeding methods
 

--- a/src/stella_vslam/tracking_module.h
+++ b/src/stella_vslam/tracking_module.h
@@ -121,6 +121,9 @@ public:
     //! If true, automatically try to relocalize when lost
     bool enable_auto_relocalization_ = true;
 
+    //! If true, automatically try to relocalize when lost
+    bool enable_temporal_keyframe_only_tracking_ = false;
+
     //! If true, use robust_matcher for relocalization request
     bool use_robust_matcher_for_relocalization_request_ = false;
 
@@ -145,6 +148,13 @@ protected:
 
     //! Main stream of the tracking module
     bool track(bool relocalization_is_needed);
+    bool track_local_map(unsigned int& num_tracked_lms,
+                         unsigned int& num_reliable_lms,
+                         unsigned int min_num_obs_thr);
+    bool track_local_map_without_temporal_keyframes(unsigned int& num_tracked_lms,
+                                                    unsigned int& num_reliable_lms,
+                                                    unsigned int min_num_obs_thr,
+                                                    unsigned int fixed_keyframe_id_threshold);
 
     //! Track the current frame
     bool track_current_frame();
@@ -167,10 +177,10 @@ protected:
                                                const unsigned int min_num_obs_thr);
 
     //! Update the local map
-    void update_local_map();
+    bool update_local_map(unsigned int fixed_keyframe_id_threshold = 0);
 
     //! Acquire more 2D-3D matches using initial camera pose estimation
-    void search_local_landmarks();
+    bool search_local_landmarks();
 
     //! Check the new keyframe is needed or not
     bool new_keyframe_is_needed(unsigned int num_tracked_lms,
@@ -209,8 +219,6 @@ protected:
     //! keyframe inserter
     module::keyframe_inserter keyfrm_inserter_;
 
-    //! local keyframes
-    std::vector<std::shared_ptr<data::keyframe>> local_keyfrms_;
     //! local landmarks
     std::vector<std::shared_ptr<data::landmark>> local_landmarks_;
 

--- a/src/stella_vslam/tracking_module.h
+++ b/src/stella_vslam/tracking_module.h
@@ -121,7 +121,7 @@ public:
     //! If true, automatically try to relocalize when lost
     bool enable_auto_relocalization_ = true;
 
-    //! If true, automatically try to relocalize when lost
+    //! If true, tracking with only temporal keyframes will not be treated as Lost
     bool enable_temporal_keyframe_only_tracking_ = false;
 
     //! If true, use robust_matcher for relocalization request


### PR DESCRIPTION
- If run with `--temporal-mapping`, keyframes loaded before running are prioritized for localization/localBA.
- If `erase_temporal_keyframes: true`, it will remove keyframes older than `num_temporal_keyframes`.
- If `enable_temporal_keyframe_only_tracking: true`, then tracking with only temporal keyframes will not be treated as Lost. If `--temporal-mapping` is not set, `enable_temporal_keyframe_only_tracking` will be ignored.
- If none of the above is specified, the behavior remains the same.
- Enabling all three of the above will run Visual SLAM with a limited number of keyframes
- If you set `--temporal-mapping` and `erase_temporal_keyframes: true`, load the map, and run it, you will get similar results to `--disable-mapping`, but the localization will be more stable.