### PR TITLE
[Bug fix] Make "Mapping" configuration field optional

### DIFF
--- a/src/stella_vslam/system.cc
+++ b/src/stella_vslam/system.cc
@@ -63,7 +63,7 @@ system::system(const std::shared_ptr<config>& cfg, const std::string& vocab_file
     // tracking module
     tracker_ = new tracking_module(cfg_, camera_, map_db_, bow_vocab_, bow_db_);
     // mapping module
-    mapper_ = new mapping_module(cfg_->yaml_node_["Mapping"], map_db_, bow_db_, bow_vocab_);
+    mapper_ = new mapping_module(util::yaml_optional_ref(cfg->yaml_node_, "Mapping"), map_db_, bow_db_, bow_vocab_);
     // global optimization module
     global_optimizer_ = new global_optimization_module(map_db_, bow_db_, bow_vocab_, cfg_->yaml_node_, camera_->setup_type_ != camera::setup_type_t::Monocular);
 


### PR DESCRIPTION
This PR addresses this issue: https://github.com/stella-cv/stella_vslam/issues/531

The solution that the poster suggested worked properly. I looked through the mapper_module to be sure and indeed all the yaml params are accessed with default values (i.e. if they arent in the yaml node, a default value is assigned). 
To be certain, I also created a modified version of aist/equirectangular.yaml wherein I removed the `Mapping:` node entirely and from the yaml file and ran the aist_entrance_hall_1 equirectangular sequence. It worked as expected. here's the console output to verify this:

```
[2024-02-11 02:02:39.967] [I] config file loaded: /stella_vslam/example/aist/mod_equirect.yaml
--start-timestamp is not set. using system timestamp.
If --no-sleep is set without --start-timestamp, timestamps may overlap between multiple runs.
[2024-02-11 02:02:39.967] [I] 
original version of OpenVSLAM,
Copyright (C) 2019,
National Institute of Advanced Industrial Science and Technology (AIST)
All rights reserved.
stella_vslam (the changes after forking from OpenVSLAM),
Copyright (C) 2022, stella-cv, All rights reserved.

This is free software,
and you are welcome to redistribute it under certain conditions.
See the LICENSE file.

Camera:
  name: RICOH THETA S 960
  setup: monocular
  model: equirectangular
  fps: 30.0
  cols: 1920
  rows: 960
  color_order: RGB
Preprocessing:
  min_size: 800
  mask_rectangles:
    - [0.0, 1.0, 0.0, 0.1]
    - [0.0, 1.0, 0.84, 1.0]
    - [0.0, 0.2, 0.7, 1.0]
    - [0.8, 1.0, 0.7, 1.0]
Feature:
  name: default ORB feature extraction setting
  scale_factor: 1.2
  num_levels: 8
  ini_fast_threshold: 20
  min_fast_threshold: 7
Tracking:
  backend: g2o
LoopDetector:
  backend: g2o
  enabled: true
  reject_by_graph_distance: true
  min_distance_on_graph: 50
System:
  map_format: msgpack

[2024-02-11 02:02:39.967] [I] loading ORB vocabulary: ./orb_vocab.fbow
[2024-02-11 02:02:39.990] [I] load orb_params "default ORB feature extraction setting"
[2024-02-11 02:02:39.991] [I] startup SLAM system
[2024-02-11 02:02:39.991] [I] start mapping module
[2024-02-11 02:02:39.992] [I] start global optimization module
[2024-02-11 02:02:40.292] [I] initialization succeeded with E
[2024-02-11 02:02:40.333] [I] new map created with 616 points: frame 0 - frame 1

```