### PR TITLE
Change build directory based on other libraries

### DIFF
--- a/Dockerfile.iridescence
+++ b/Dockerfile.iridescence
@@ -187,6 +187,7 @@ RUN set -x && \
 
 # Build and install Iridescence
 ARG IRIDESCENCE_COMMIT=085322e0c949f75b67d24d361784e85ad7f197ab
+WORKDIR /tmp
 RUN set -x && \
   git clone https://github.com/koide3/iridescence && \
   cd iridescence && \


### PR DESCRIPTION
Hello,

I have made a change to the build directory for Iridescence. While other libraries are built in the `/tmp` directory, Iridescence is now built in the `/stella_vslam` directory.

Thank you.