### PR TITLE
[Issue #626] - Frame publisher function to get landmarks and keypoints with lock held

### DIFF
--- a/src/stella_vslam/publish/frame_publisher.cc
+++ b/src/stella_vslam/publish/frame_publisher.cc
@@ -94,6 +94,12 @@ std::string frame_publisher::get_tracking_state() {
     return state_str;
 }
 
+std::pair<std::vector<cv::KeyPoint>, std::vector<std::shared_ptr<data::landmark>>> frame_publisher::get_landmarks_and_keypoints() {
+    std::lock_guard<std::mutex> lock(mtx_);
+
+    return std::make_pair(curr_keypts_, curr_lms_);
+}
+
 std::vector<cv::KeyPoint> frame_publisher::get_keypoints() {
     std::lock_guard<std::mutex> lock(mtx_);
     return curr_keypts_;
@@ -194,6 +200,7 @@ void frame_publisher::update(const std::vector<std::shared_ptr<data::landmark>>&
 
     img.copyTo(img_);
 
+    assert(keypts.size() == curr_lms.size());
     curr_keypts_ = keypts;
     tracking_time_elapsed_ms_ = tracking_time_elapsed_ms;
     extraction_time_elapsed_ms_ = extraction_time_elapsed_ms;

--- a/src/stella_vslam/publish/frame_publisher.cc
+++ b/src/stella_vslam/publish/frame_publisher.cc
@@ -94,7 +94,7 @@ std::string frame_publisher::get_tracking_state() {
     return state_str;
 }
 
-std::pair<std::vector<cv::KeyPoint>, std::vector<std::shared_ptr<data::landmark>>> frame_publisher::get_landmarks_and_keypoints() {
+std::pair<std::vector<cv::KeyPoint>, std::vector<std::shared_ptr<data::landmark>>> frame_publisher::get_keypoints_and_landmarks() {
     std::lock_guard<std::mutex> lock(mtx_);
 
     return std::make_pair(curr_keypts_, curr_lms_);

--- a/src/stella_vslam/publish/frame_publisher.h
+++ b/src/stella_vslam/publish/frame_publisher.h
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <vector>
 #include <memory>
+#include <utility>
 
 #include <opencv2/core/mat.hpp>
 #include <opencv2/core/types.hpp>
@@ -60,6 +61,8 @@ public:
     bool get_mapping_is_enabled();
 
     std::vector<std::shared_ptr<data::landmark>> get_landmarks();
+
+    std::pair<std::vector<cv::KeyPoint>, std::vector<std::shared_ptr<data::landmark>>> get_landmarks_and_keypoints();
 
     cv::Mat get_image();
 

--- a/src/stella_vslam/publish/frame_publisher.h
+++ b/src/stella_vslam/publish/frame_publisher.h
@@ -62,7 +62,7 @@ public:
 
     std::vector<std::shared_ptr<data::landmark>> get_landmarks();
 
-    std::pair<std::vector<cv::KeyPoint>, std::vector<std::shared_ptr<data::landmark>>> get_landmarks_and_keypoints();
+    std::pair<std::vector<cv::KeyPoint>, std::vector<std::shared_ptr<data::landmark>>> get_keypoints_and_landmarks();
 
     cv::Mat get_image();
 


### PR DESCRIPTION
Landmarks are made from the size of undistorted keypoints, so they are exactly the same size.
If frame_publisher::update() is called in between get_keypoints() and get_landmarks() this assertion may not hold.

Add function which returns both in a pair without releasing the mutex lock